### PR TITLE
Add support for "Mahoutsukai" and fix "Gekijyouban"

### DIFF
--- a/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
@@ -79,10 +79,10 @@ namespace Jellyfin.Plugin.AniDB.Providers
 
             // "words"
             a = _sAtEndBoundaryRegex.Replace(a, ".?s");
-            a = a.Replace("re", "re.?", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("Gekijyouban", "Gekijouban", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("Mahoutsukai", "Mahou ?tsukai", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("to aru", "to ?aru", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("re", "re.?", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("OVA", "((OVA)|(OAD))", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("OAD", "((OVA)|(OAD))", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("c", "(c|k)", StringComparison.OrdinalIgnoreCase);

--- a/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
@@ -79,15 +79,16 @@ namespace Jellyfin.Plugin.AniDB.Providers
 
             // "words"
             a = _sAtEndBoundaryRegex.Replace(a, ".?s");
+            a = a.Replace("re", "re.?", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("Gekijyouban", "Gekijouban", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("Mahoutsukai", "Mahou ?tsukai", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("to aru", "to ?aru", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("OVA", "((OVA)|(OAD))", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("OAD", "((OVA)|(OAD))", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("c", "(c|k)", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("k", "(c|k)", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("&", "(&|(and))", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("and", "(&|(and))", StringComparison.OrdinalIgnoreCase);
-            a = a.Replace("OVA", "((OVA)|(OAD))", StringComparison.OrdinalIgnoreCase);
-            a = a.Replace("OAD", "((OVA)|(OAD))", StringComparison.OrdinalIgnoreCase);
-            a = a.Replace("re", "re.?", StringComparison.OrdinalIgnoreCase);
-            a = a.Replace("Gekijyouban", "Gekijouban", StringComparison.OrdinalIgnoreCase);
-            a = a.Replace("to aru", "to.?aru", StringComparison.OrdinalIgnoreCase);
 
             return a;
         }


### PR DESCRIPTION
魔法使い is often romanized as "Mahoutsukai", however AniDB uses "Mahou Tsukai". 

Also, I moved the words to the top, because they should get replaced before c and k get made interchangeable.