### PR TITLE
Add AniDb Season ProviderId

### DIFF
--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/AniDbExternalId.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/AniDbExternalId.cs
@@ -9,7 +9,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB
     public class AniDbExternalId : IExternalId
     {
         public bool Supports(IHasProviderIds item)
-            => item is Series || item is Movie;
+            => item is Series || item is Season || item is Movie;
 
         public string ProviderName
             => "AniDB";

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbMovieProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbMovieProvider.cs
@@ -37,7 +37,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
 
             if (!string.IsNullOrEmpty(animeId))
             {
-                var seriesResult = await _seriesProvider.GetMetadataForId(animeId, seriesInfo, cancellationToken);
+                var seriesResult = await _seriesProvider.GetMetadataForId(animeId, seriesInfo.MetadataLanguage, cancellationToken);
 
                 if (seriesResult.HasMetadata)
                 {

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonProvider.cs
@@ -29,6 +29,21 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
             if (string.IsNullOrEmpty(animeId) && (info.IndexNumber == 1 || (Plugin.Instance.Configuration.IgnoreSeason && info.IndexNumber > 0)))
             {
                 animeId = info.SeriesProviderIds.GetOrDefault(ProviderNames.AniDb);
+
+                if (!string.IsNullOrEmpty(animeId))
+                {
+                    var result = new MetadataResult<Season>
+                    {
+                        HasMetadata = true,
+                        Item = new Season
+                        {
+                            Name = info.Name,
+                            IndexNumber = info.IndexNumber
+                        }
+                    };
+                    result.Item.ProviderIds.Add(ProviderNames.AniDb, animeId);
+                    return result;
+                }
             }
 
             /* if (!string.IsNullOrEmpty(animeId))

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -64,13 +64,13 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
 
             if (!string.IsNullOrEmpty(animeId))
             {
-                return await GetMetadataForId(animeId, info, cancellationToken);
+                return await GetMetadataForId(animeId, info.MetadataLanguage, cancellationToken);
             }
 
             return new MetadataResult<Series>();
         }
 
-        public async Task<MetadataResult<Series>> GetMetadataForId(string animeId, SeriesInfo info, CancellationToken cancellationToken)
+        public async Task<MetadataResult<Series>> GetMetadataForId(string animeId, string MetadataLanguage, CancellationToken cancellationToken)
         {
             var result = new MetadataResult<Series>();
 
@@ -80,7 +80,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
             result.Item.ProviderIds.Add(ProviderNames.AniDb, animeId);
 
             var seriesDataPath = await GetSeriesData(_appPaths, animeId, cancellationToken);
-            await FetchSeriesInfo(result, seriesDataPath, info.MetadataLanguage ?? "en").ConfigureAwait(false);
+            await FetchSeriesInfo(result, seriesDataPath, MetadataLanguage ?? "en").ConfigureAwait(false);
 
             return result;
         }
@@ -92,7 +92,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
 
             if (!string.IsNullOrEmpty(animeId))
             {
-                var resultMetadata = await GetMetadataForId(animeId, searchInfo, cancellationToken);
+                var resultMetadata = await GetMetadataForId(animeId, searchInfo.MetadataLanguage, cancellationToken);
 
                 if (resultMetadata.HasMetadata)
                 {
@@ -124,7 +124,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
 
             foreach (string id in ids)
             {
-                var resultMetadata = await GetMetadataForId(id, searchInfo, cancellationToken);
+                var resultMetadata = await GetMetadataForId(id, searchInfo.MetadataLanguage, cancellationToken);
 
                 if (resultMetadata.HasMetadata)
                 {


### PR DESCRIPTION
I updated getting metadata for seasons, however it currently doesn't make sense to do so because you can't get the SeasonProviderIds for episodes (there is no info.SeasonProviderIds) and therefore you can't get the correct episode metadata for season other than the main one, whose Id would also be in info.SeriesProviderIds. 
Therefore I commented it out and the only noticeable change this PR makes is adding the ProviderId for seasons. 

Old behaviour:
- create empty MetadataResult<Season>
- get ProviderId
- ProviderId isn't set
  - --> return empty result created earlier
- if you set the ProviderId manually, it adds the metadata for that to the season, but the episodes have the metadata for the show independently of the season (doesn't make sense)

New behaviour:
- get ProviderId
- if ProviderId not set: 
  - add ProviderId from show to the season (if it's season 1 or IgnoreSeason is true) and return
- code to get metadata is commented out because it currently doesn't make sense (but could be implemented in the future if SeasonProviderIds gets added to the EpisodeInfo class in jellyfin)
- return empty MetadataResult<Season>

Shokofin adds the ProviderId for seasons, and has support for different seasons, I believe. 
For better interoperability with plugins like [jellyfin-ani-sync](https://github.com/vosmiic/jellyfin-ani-sync) this plugin should add the ProviderId for seasons too.