### PR TITLE
Detect api errors and throw exception

### DIFF
--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -32,6 +32,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
         public static readonly RateLimiter RequestLimiter = new RateLimiter(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
         private static readonly int[] IgnoredTagIds = { 6, 22, 23, 60, 128, 129, 185, 216, 242, 255, 268, 269, 289 };
         private static readonly Regex AniDbUrlRegex = new Regex(@"https?://anidb.net/\w+(/[0-9]+)? \[(?<name>[^\]]*)\]", RegexOptions.Compiled);
+        private static readonly Regex _errorRegex = new(@"<error code=""[0-9]+"">[a-zA-Z]+</error>", RegexOptions.Compiled);
         private readonly IApplicationPaths _appPaths;
 
         private readonly Dictionary<string, string> _typeMappings = new Dictionary<string, string>
@@ -577,6 +578,12 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
             {
                 var text = await reader.ReadToEndAsync().ConfigureAwait(false);
                 text = text.Replace("&#x0;", "");
+
+                var errorRegexMatch = _errorRegex.Match(text);
+                if (errorRegexMatch.Success)
+                {
+                    throw new Exception("AniDB API error " + errorRegexMatch.Value);
+                }
 
                 await writer.WriteAsync(text).ConfigureAwait(false);
             }


### PR DESCRIPTION
This prevents issues like #39 from reoccurring and makes diagnosing api errors easier because the exception will be written to the logs instead of silently saving a file with the error message instead of the metadata.