### PR TITLE
Make series.xml cache age user configurable

### DIFF
--- a/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
@@ -38,6 +38,7 @@ namespace Jellyfin.Plugin.AniDB.Configuration
             TitleCaseGenres = false;
             AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
             AniDbRateLimit = 2000;
+            MaxCacheAge = 7;
             AniDbReplaceGraves = true;
         }
 
@@ -58,6 +59,8 @@ namespace Jellyfin.Plugin.AniDB.Configuration
         public AnimeDefaultGenreType AnimeDefaultGenre { get; set; }
 
         public int AniDbRateLimit { get; set; }
+
+        public int MaxCacheAge { get; set; }
 
         public bool AniDbReplaceGraves { get; set; }
     }

--- a/Jellyfin.Plugin.AniDB/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniDB/Configuration/configPage.html
@@ -68,6 +68,11 @@
                             <input id="chkAniDbRateLimit" name="chkAniDbRateLimit" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">This will prevent IP bans for requesting data too quickly.</div>
                         </div>
+                        <div class="inputContainer">
+                            <label class="inputeLabel inputLabelUnfocused" for="chkMaxCacheAge">Maximum Cache Age</label>
+                            <input id="chkMaxCacheAge" name="chkMaxCacheAge" type="number" is="emby-input" min="0" />
+                            <div class="fieldDescription">How many days cached series metadata will be reused before fetching new metatdata from AniDB.</div>
+                        </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
                                 <input id="chkAniDbReplaceGraves" name="chkAniDbReplaceGraves" type="checkbox" is="emby-checkbox" />
@@ -100,6 +105,7 @@
                             document.getElementById('chkTidyGenres').checked = config.TidyGenreList;
                             document.getElementById('animeDefaultGenre').value = config.AnimeDefaultGenre;
                             document.getElementById('chkAniDbRateLimit').value = config.AniDbRateLimit;
+                            document.getElementById('chkMaxCacheAge').value = config.MaxCacheAge;
                             document.getElementById('chkAniDbReplaceGraves').checked = config.AniDbReplaceGraves;
 
                             Dashboard.hideLoadingMsg();
@@ -119,6 +125,7 @@
                             config.TidyGenreList = document.getElementById('chkTidyGenres').checked;
                             config.AnimeDefaultGenre = document.getElementById('animeDefaultGenre').value;
                             config.AniDbRateLimit = document.getElementById('chkAniDbRateLimit').value;
+                            config.MaxCacheAge = document.getElementById('chkMaxCacheAge').value;
                             config.AniDbReplaceGraves = document.getElementById('chkAniDbReplaceGraves').checked;
 
                             ApiClient.updatePluginConfiguration(AniDBConfigurationPage.pluginUniqueId, config).then(function (result) {

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -162,7 +162,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
             var fileInfo = new FileInfo(seriesDataPath);
 
             // download series data if not present or out of date
-            if (!fileInfo.Exists || DateTime.UtcNow - fileInfo.LastWriteTimeUtc > TimeSpan.FromDays(7))
+            if (!fileInfo.Exists || DateTime.UtcNow - fileInfo.LastWriteTimeUtc > TimeSpan.FromDays(Plugin.Instance.Configuration.MaxCacheAge))
             {
                 await DownloadSeriesData(seriesId, seriesDataPath, appPaths.CachePath, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
By default, the plugin will only download new metadata from AniDB if the existing xml file is older than seven days. This PR allows this value to be user configurable.