### PR TITLE
Add wo replacement

### DIFF
--- a/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
@@ -85,6 +85,7 @@ namespace Jellyfin.Plugin.AniDB.Providers
             a = a.Replace("re", "re.?", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("OVA", "((OVA)|(OAD))", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("OAD", "((OVA)|(OAD))", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("wo", "w?o", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("c", "(c|k)", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("k", "(c|k)", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("&", "(&|(and))", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
を (wo) is read like o and transliterated as o in some systems.

Example:  Kubo-san wa Mob (w)o Yurusanai 
https://anidb.net/anime/17360
https://anilist.co/anime/148969/