### PR TITLE
Parse the AniDB ID from the path if possible

### DIFF
--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -33,7 +33,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
         public static readonly RateLimiter RequestLimiter = new RateLimiter(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
         private static readonly int[] IgnoredTagIds = { 6, 22, 23, 60, 128, 129, 185, 216, 242, 255, 268, 269, 289 };
         private static readonly Regex AniDbUrlRegex = new Regex(@"https?://anidb.net/\w+(/[0-9]+)? \[(?<name>[^\]]*)\]", RegexOptions.Compiled);
-        private static readonly Regex AniDbIdRegex = new Regex(@"\[anidb-([0-9]+)\]", RegexOptions.Compiled);
+        private static readonly Regex AniDbIdRegex = new Regex(@"\[anidb(id)?-(?<anidb_id>[0-9]+)\]", RegexOptions.Compiled);
         private static readonly Regex _errorRegex = new(@"<error code=""[0-9]+"">[a-zA-Z]+</error>", RegexOptions.Compiled);
         private readonly IApplicationPaths _appPaths;
 
@@ -61,9 +61,8 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
             if (!string.IsNullOrEmpty(path))
             {
                 var match = AniDbIdRegex.Match(path);
-                if (match is { Success: true, Groups.Count: 2 })
-                {
-                    return match.Groups[1].Value;
+                if (match.Success) {
+                    return match.Groups["anidb_id"].Value;
                 }
             }
             return string.Empty;

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -33,7 +33,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
         public static readonly RateLimiter RequestLimiter = new RateLimiter(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
         private static readonly int[] IgnoredTagIds = { 6, 22, 23, 60, 128, 129, 185, 216, 242, 255, 268, 269, 289 };
         private static readonly Regex AniDbUrlRegex = new Regex(@"https?://anidb.net/\w+(/[0-9]+)? \[(?<name>[^\]]*)\]", RegexOptions.Compiled);
-        private static readonly Regex AniDbIdRegex = new Regex(@"\[anidb-(\d+)\]", RegexOptions.Compiled);
+        private static readonly Regex AniDbIdRegex = new Regex(@"\[anidb-([0-9]+)\]", RegexOptions.Compiled);
         private static readonly Regex _errorRegex = new(@"<error code=""[0-9]+"">[a-zA-Z]+</error>", RegexOptions.Compiled);
         private readonly IApplicationPaths _appPaths;
 

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -71,10 +71,10 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
 
         public async Task<MetadataResult<Series>> GetMetadata(SeriesInfo info, CancellationToken cancellationToken)
         {
-            var animeId = GetAniDbIdFromPath(info.Path);
+            var animeId = info.ProviderIds.GetOrDefault(ProviderNames.AniDb);
             if (string.IsNullOrEmpty(animeId)) 
             {
-                animeId = info.ProviderIds.GetOrDefault(ProviderNames.AniDb);
+                animeId = GetAniDbIdFromPath(info.Path);
             }
 
             if (string.IsNullOrEmpty(animeId) && !string.IsNullOrEmpty(info.Name))

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -60,10 +60,10 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
         {
             if (!string.IsNullOrEmpty(path))
             {
-                MatchCollection idMatches = AniDbIdRegex.Matches(path);
-                if (idMatches.Count == 1)
+                var match = AniDbIdRegex.Match(path);
+                if (match is { Success: true, Groups.Count: 2 })
                 {
-                    return idMatches[0].Groups[1].Value;
+                    return match.Groups[1].Value;
                 }
             }
             return string.Empty;


### PR DESCRIPTION
Match the behavior of https://github.com/ZeroQI/Absolute-Series-Scanner - a Plex plugin.

I include anidb ids in the names of my anime directories to avoid incorrect matches. This PR will parse those out and use them, if it finds exactly one in the path. I've tested it and it works for my library.

Without this change, as an example, the plugin matched every season of a show in my library as season 1.

I'm open to and would appreciate feedback.