### PR TITLE
fix: download if the file has zero length

### DIFF
--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -163,8 +163,10 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
             var seriesDataPath = Path.Combine(dataPath, SeriesDataFile);
             var fileInfo = new FileInfo(seriesDataPath);
 
-            // download series data if not present or out of date
-            if (!fileInfo.Exists || DateTime.UtcNow - fileInfo.LastWriteTimeUtc > TimeSpan.FromDays(Plugin.Instance.Configuration.MaxCacheAge))
+            var isEmpty = fileInfo.Exists && fileInfo.Length == 0;
+            var isStale = fileInfo.Exists && DateTime.UtcNow - fileInfo.LastWriteTimeUtc > TimeSpan.FromDays(Plugin.Instance.Configuration.MaxCacheAge);
+
+            if (!fileInfo.Exists || isEmpty || isStale)
             {
                 await DownloadSeriesData(seriesId, seriesDataPath, appPaths.CachePath, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
When we get banned from anidb an empty file is left causing failure when we get unbanned because it won't try to download again.  This checks if the file is empty and forces a download as well.