### PR TITLE
Only show defined person images

### DIFF
--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbPersonProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbPersonProvider.cs
@@ -83,7 +83,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
             var infos = new List<RemoteImageInfo>();
 
             var person = AniDbSeriesProvider.GetPersonInfo(_paths.CachePath, item.Name);
-            if (person != null && String.IsNullOrEmpty(person.Image))
+            if (person != null && !String.IsNullOrEmpty(person.Image))
             {
                 infos.Add(new RemoteImageInfo
                 {

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbPersonProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbPersonProvider.cs
@@ -83,7 +83,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
             var infos = new List<RemoteImageInfo>();
 
             var person = AniDbSeriesProvider.GetPersonInfo(_paths.CachePath, item.Name);
-            if (person != null)
+            if (person != null && person.Image != null)
             {
                 infos.Add(new RemoteImageInfo
                 {

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbPersonProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbPersonProvider.cs
@@ -83,7 +83,7 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata
             var infos = new List<RemoteImageInfo>();
 
             var person = AniDbSeriesProvider.GetPersonInfo(_paths.CachePath, item.Name);
-            if (person != null && person.Image != null)
+            if (person != null && String.IsNullOrEmpty(person.Image))
             {
                 infos.Add(new RemoteImageInfo
                 {


### PR DESCRIPTION
Response has often no imageID inside XML (yes sometimes it exists on anidb  - API something), not better compared to showing undefined images

Fixes People scan as well, that tries t load the images
```
[WRN] [47] Emby.Server.Implementations.Library.LibraryManager: Primary image for FistName LastName (UUID) not found at "", source was
```