### PR TITLE
Fix matching logic

### DIFF
--- a/Jellyfin.Plugin.AniDB/Api/AniDbSourceCheck.cs
+++ b/Jellyfin.Plugin.AniDB/Api/AniDbSourceCheck.cs
@@ -1,0 +1,18 @@
+namespace Jellyfin.Plugin.AniDB.Api;
+
+/// <summary>
+/// What asking the downloaded mapping sources what they hold came to, as the configuration
+/// page reports it after the button that asks for one.
+/// </summary>
+public class AniDbSourceCheck
+{
+    /// <summary>
+    /// Gets or sets what checking the AniBridge mappings came to.
+    /// </summary>
+    public string AniBridge { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets what checking the anime list came to.
+    /// </summary>
+    public string AnimeList { get; set; } = string.Empty;
+}

--- a/Jellyfin.Plugin.AniDB/Api/AniDbStatus.cs
+++ b/Jellyfin.Plugin.AniDB/Api/AniDbStatus.cs
@@ -1,0 +1,133 @@
+using System;
+
+namespace Jellyfin.Plugin.AniDB.Api;
+
+/// <summary>
+/// How the plugin currently stands with AniDB, as the configuration page shows it.
+/// </summary>
+public class AniDbStatus
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether AniDB is currently refusing requests, so that
+    /// none will be sent until the pause has run out.
+    /// </summary>
+    public bool IsBanned { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many seconds are left of that pause.
+    /// </summary>
+    public double BanRemainingSeconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many requests are waiting for a slot behind the rate limit.
+    /// </summary>
+    public int QueuedRequests { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many seconds are left before the next request may be sent.
+    /// </summary>
+    public double NextRequestInSeconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many requests have been sent to AniDB since the server started.
+    /// </summary>
+    public long RequestsSent { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the last request was sent, or <c>null</c> when none has been.
+    /// </summary>
+    public DateTime? LastRequestUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configured gap between two requests, in milliseconds.
+    /// </summary>
+    public int RequestIntervalMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the cached copy of the anime list was downloaded, or <c>null</c>
+    /// when none has been.
+    /// </summary>
+    public DateTime? AnimeListCachedAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the anime list was last asked whether it holds a copy newer than the
+    /// cached one, or <c>null</c> where it has never been asked. Later than the download
+    /// wherever a check found the cached copy to be the current one.
+    /// </summary>
+    public DateTime? AnimeListCheckedAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many AniDB entries have been read from that copy. Zero until the
+    /// first season is looked up, which is when the list is first read.
+    /// </summary>
+    public int AnimeListEntryCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many days the cached copy is used for before it is downloaded again.
+    /// </summary>
+    public int AnimeListMaxAgeDays { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the cached copy of the AniBridge mappings was downloaded, or
+    /// <c>null</c> when none has been.
+    /// </summary>
+    public DateTime? AniBridgeCachedAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the AniBridge release was last asked whether it carries a build newer
+    /// than the cached one, or <c>null</c> where it has never been asked. Later than the
+    /// download wherever a check found the cached build to be the current one.
+    /// </summary>
+    public DateTime? AniBridgeCheckedAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many AniDB entries have been read from that copy. Zero until the
+    /// first season is looked up, which is when the mappings are first read.
+    /// </summary>
+    public int AniBridgeEntryCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many days the cached copy is used for before it is downloaded again.
+    /// </summary>
+    public int AniBridgeMaxAgeDays { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the AniBridge mappings are consulted at all.
+    /// </summary>
+    public bool AniBridgeEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets where the mapping overrides are read from, whether or not a file is there.
+    /// Nothing downloads that file, so the page has to say where to put one.
+    /// </summary>
+    public string OverridesPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets when the override file was last written, or <c>null</c> where there is no
+    /// such file, which is the ordinary state of an installation.
+    /// </summary>
+    public DateTime? OverridesWrittenAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many AniDB entries have been read from it, as it stands on disk now:
+    /// the file is read afresh whenever this is asked for.
+    /// </summary>
+    public int OverridesEntryCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many shows those entries are placed in, which is fewer wherever a show
+    /// is placed by several of them.
+    /// </summary>
+    public int OverridesShowCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many movies it identifies, which a file may state instead of any season.
+    /// </summary>
+    public int OverridesMovieCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets why the file could not be read, or <c>null</c> where it was read. A file
+    /// written by hand is broken by hand, and the page is where whoever wrote it is looking.
+    /// </summary>
+    public string? OverridesError { get; set; }
+}

--- a/Jellyfin.Plugin.AniDB/Api/AniDbStatusController.cs
+++ b/Jellyfin.Plugin.AniDB/Api/AniDbStatusController.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Net.Mime;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+using MediaBrowser.Common.Configuration;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AniDB.Api;
+
+/// <summary>
+/// Reports what the plugin is doing with AniDB, so that the configuration page can say
+/// whether requests are flowing, queued or paused by a ban.
+/// </summary>
+/// <param name="applicationPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+/// <param name="logger">Instance of the <see cref="ILogger{TCategoryName}"/> interface.</param>
+[ApiController]
+[Authorize(Policy = "RequiresElevation")]
+[Route("AniDB")]
+[Produces(MediaTypeNames.Application.Json)]
+public class AniDbStatusController(IApplicationPaths applicationPaths, ILogger<AniDbStatusController> logger) : ControllerBase
+{
+    private readonly IApplicationPaths _applicationPaths = applicationPaths;
+    private readonly ILogger<AniDbStatusController> _logger = logger;
+
+    /// <summary>
+    /// Gets the plugin's current standing with AniDB.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">Status returned.</response>
+    /// <returns>The status.</returns>
+    [HttpGet("Status")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<AniDbStatus>> GetStatus(CancellationToken cancellationToken)
+    {
+        var (banRemaining, queued, untilNext, sent, lastSentUtc) = AniDbSeriesProvider.GetRequestStatus();
+        var (cachedAtUtc, checkedAtUtc, entryCount, maxAgeInDays) = AniDbAnimeList.GetStatus(_applicationPaths);
+        var (bridgeCachedAtUtc, bridgeCheckedAtUtc, bridgeEntryCount, bridgeMaxAgeInDays) = AniBridgeMappings.GetStatus(_applicationPaths);
+
+        // Read from disk as it stands rather than as it was last read, which is what makes an
+        // edit to it show up on the page it is made for.
+        var (overridesPath, overridesWrittenAtUtc, overridesEntryCount, overridesShowCount, overridesMovieCount, overridesError) =
+            await AniDbMappingOverrides.GetStatus(_applicationPaths, _logger, cancellationToken).ConfigureAwait(false);
+
+        return new AniDbStatus
+        {
+            IsBanned = banRemaining > TimeSpan.Zero,
+            BanRemainingSeconds = banRemaining.TotalSeconds,
+            QueuedRequests = queued,
+            NextRequestInSeconds = untilNext.TotalSeconds,
+            RequestsSent = sent,
+            LastRequestUtc = lastSentUtc,
+            RequestIntervalMs = Plugin.Instance.Configuration.RequestIntervalMs,
+            AnimeListCachedAtUtc = cachedAtUtc,
+            AnimeListCheckedAtUtc = checkedAtUtc,
+            AnimeListEntryCount = entryCount,
+            AnimeListMaxAgeDays = maxAgeInDays,
+            AniBridgeCachedAtUtc = bridgeCachedAtUtc,
+            AniBridgeCheckedAtUtc = bridgeCheckedAtUtc,
+            AniBridgeEntryCount = bridgeEntryCount,
+            AniBridgeMaxAgeDays = bridgeMaxAgeInDays,
+            AniBridgeEnabled = Plugin.Instance.Configuration.UseAniBridgeMappings,
+            OverridesPath = overridesPath,
+            OverridesWrittenAtUtc = overridesWrittenAtUtc,
+            OverridesEntryCount = overridesEntryCount,
+            OverridesShowCount = overridesShowCount,
+            OverridesMovieCount = overridesMovieCount,
+            OverridesError = overridesError
+        };
+    }
+
+    /// <summary>
+    /// Asks both downloaded mapping sources what they hold now, whatever the age of the copies
+    /// cached, and downloads whichever has changed since. The overrides are not among them:
+    /// nothing downloads that file, and it is read afresh whenever the status above is asked
+    /// for. Neither is the AniDB titles list, which comes from AniDB itself and is paced to
+    /// keep off its ban list rather than fetched on request.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">Sources checked.</response>
+    /// <returns>What each check came to.</returns>
+    [HttpPost("Sources/Check")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<AniDbSourceCheck>> CheckSources(CancellationToken cancellationToken)
+    {
+        // Both at once: they come from different hosts, and neither waits behind AniDB's rate
+        // limit. Each holds its own gate, so a scan asking for the same source meanwhile waits
+        // rather than downloading it a second time.
+        var bridge = AniBridgeMappings.CheckNow(_applicationPaths, _logger, cancellationToken);
+        var list = AniDbAnimeList.CheckNow(_applicationPaths, _logger, cancellationToken);
+
+        var outcomes = await Task.WhenAll(bridge, list).ConfigureAwait(false);
+
+        return new AniDbSourceCheck
+        {
+            AniBridge = Describe(outcomes[0]),
+            AnimeList = Describe(outcomes[1])
+        };
+    }
+
+    /// <summary>
+    /// How a check reads on the page that asked for it.
+    /// </summary>
+    /// <param name="check">What the check came to.</param>
+    /// <returns>The wording to show.</returns>
+    private static string Describe(MappingSourceCheck check) => check switch
+    {
+        MappingSourceCheck.Updated => "a newer copy was downloaded",
+        MappingSourceCheck.Unchanged => "already the current copy",
+        MappingSourceCheck.NotUsed => "not used",
+        MappingSourceCheck.NotDownloaded => "not downloaded",
+        _ => "could not be checked - see the server log"
+    };
+}

--- a/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
@@ -73,6 +73,7 @@ public class PluginConfiguration : BasePluginConfiguration
         MinimumTagWeight = DefaultMinimumTagWeight;
         InfoboxTagsOnly = false;
         TagBlacklist = string.Empty;
+        UseAniBridgeMappings = true;
     }
 
     /// <summary>
@@ -123,6 +124,15 @@ public class PluginConfiguration : BasePluginConfiguration
     /// filled from. With this off the season keeps the name Jellyfin gave it.
     /// </summary>
     public bool UseAniDbSeasonNames { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the AniBridge mappings are consulted before the
+    /// anime list. They place half again as many AniDB entries, state each placement's episode
+    /// ranges outright, and are the only source here that carries TMDB show ids. Turning them
+    /// off leaves the anime list to place everything, as it did before they were added, which is
+    /// worth doing only where they place a show wrongly.
+    /// </summary>
+    public bool UseAniBridgeMappings { get; set; }
 
     /// <summary>
     /// Gets or sets the shortest gap, in milliseconds, between two AniDB requests. Clamped to

--- a/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
@@ -31,13 +31,28 @@ public enum AnimeDefaultGenreType
 public class PluginConfiguration : BasePluginConfiguration
 {
     /// <summary>
-    /// The shortest cache window AniDB metadata may be reused for. AniDB permits only a low
-    /// number of requests per IP per day, so a shorter window would make a library of any
-    /// size impossible to scan without being banned.
+    /// The shortest cache window AniDB metadata may be reused for. AniDB permits few requests
+    /// per IP per day, and a shorter window would get a library of any size banned mid-scan.
     /// </summary>
     public const int MinimumCacheAgeDays = 7;
 
+    /// <summary>
+    /// The shortest gap between two AniDB requests. AniDB bans a client that sends them
+    /// closer together than roughly two seconds, so no lower value is accepted.
+    /// </summary>
+    public const int MinimumRequestIntervalMs = 2500;
+
+    /// <summary>
+    /// The tag weight AniDB itself treats as the line between a tag that describes the show
+    /// and one a single user attached to it.
+    /// </summary>
+    public const int DefaultMinimumTagWeight = 400;
+
     private int _maxCacheAge = MinimumCacheAgeDays;
+
+    private int _requestIntervalMs = MinimumRequestIntervalMs;
+
+    private string _tagBlacklist = string.Empty;
 
     public PluginConfiguration()
     {
@@ -47,10 +62,18 @@ public class PluginConfiguration : BasePluginConfiguration
         TitleSimilarityThreshold = 50;
         MaxGenres = 5;
         TidyGenreList = true;
-        TitleCaseGenres = false;
+        TitleCaseGenres = true;
         AnimeDefaultGenre = AnimeDefaultGenreType.Anime;
         MaxCacheAge = 7;
         AniDbReplaceGraves = true;
+        IncludeAdultTags = false;
+        ImportGenres = true;
+        ImportTags = true;
+        UseAniDbSeasonNames = true;
+        RequestIntervalMs = MinimumRequestIntervalMs;
+        MinimumTagWeight = DefaultMinimumTagWeight;
+        InfoboxTagsOnly = false;
+        TagBlacklist = string.Empty;
     }
 
     public TitlePreferenceType TitlePreference { get; set; }
@@ -62,6 +85,18 @@ public class PluginConfiguration : BasePluginConfiguration
     public int TitleSimilarityThreshold { get; set; }
 
     public int MaxGenres { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether AniDB's tags are shown as genres at all. With
+    /// this off the genre list is left to whichever other provider fills it.
+    /// </summary>
+    public bool ImportGenres { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether AniDB's tags are kept as tags. Independent of
+    /// <see cref="ImportGenres"/>.
+    /// </summary>
+    public bool ImportTags { get; set; }
 
     public bool TidyGenreList { get; set; }
 
@@ -82,15 +117,63 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool AniDbReplaceGraves { get; set; }
 
     /// <summary>
-    /// Gets or sets the UTC time at which an AniDB ban is assumed to lapse. Persisted so
-    /// that restarting the server does not hand a banned client a fresh allowance of
-    /// requests. This is runtime state rather than a user setting.
+    /// Gets or sets a value indicating whether a season is named after the AniDB entry it was
+    /// filled from. With this off the season keeps the name Jellyfin gave it.
+    /// </summary>
+    public bool UseAniDbSeasonNames { get; set; }
+
+    /// <summary>
+    /// Gets or sets the shortest gap, in milliseconds, between two AniDB requests. Clamped to
+    /// at least <see cref="MinimumRequestIntervalMs"/>. AniDB counts requests per IP, so raise
+    /// this to leave room for another client on the same address.
+    /// </summary>
+    public int RequestIntervalMs
+    {
+        get => Math.Max(_requestIntervalMs, MinimumRequestIntervalMs);
+        set => _requestIntervalMs = value;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the tags AniDB flags as 18+ content are kept.
+    /// They are dropped by default. Anime AniDB flags as adult are rated as such either way,
+    /// which is what parental controls act on.
+    /// </summary>
+    public bool IncludeAdultTags { get; set; }
+
+    /// <summary>
+    /// Gets or sets the weight a tag needs before it is imported. AniDB weights a tag by how
+    /// much of the show it describes, so raising this keeps only the tags that characterise
+    /// it.
+    /// </summary>
+    public int MinimumTagWeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether only the tags AniDB shows in the infobox on the
+    /// anime's page are imported. Those are the ones AniDB considers to describe the show
+    /// rather than its setting or its cast.
+    /// </summary>
+    public bool InfoboxTagsOnly { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tag names never to import, one per line or separated by commas.
+    /// Matched whole and without regard to case.
+    /// </summary>
+    public string TagBlacklist
+    {
+        get => _tagBlacklist;
+        set => _tagBlacklist = value ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Gets or sets the UTC time at which an AniDB ban is assumed to lapse. Persisted so that
+    /// restarting the server does not hand a banned client a fresh allowance. Runtime state
+    /// rather than a user setting.
     /// </summary>
     public DateTime AniDbBannedUntilUtc { get; set; }
 
     /// <summary>
-    /// Gets or sets the backoff, in minutes, that will be applied to the next detected
-    /// AniDB ban. This is runtime state rather than a user setting.
+    /// Gets or sets the backoff, in minutes, applied to the next detected AniDB ban. Runtime
+    /// state rather than a user setting.
     /// </summary>
     public int AniDbBanBackoffMinutes { get; set; }
 }

--- a/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
@@ -57,7 +57,6 @@ public class PluginConfiguration : BasePluginConfiguration
     public PluginConfiguration()
     {
         TitlePreference = TitlePreferenceType.Localized;
-        OriginalTitlePreference = TitlePreferenceType.JapaneseRomaji;
         IgnoreSeason = false;
         TitleSimilarityThreshold = 50;
         MaxGenres = 5;
@@ -76,9 +75,12 @@ public class PluginConfiguration : BasePluginConfiguration
         TagBlacklist = string.Empty;
     }
 
+    /// <summary>
+    /// Gets or sets the language the displayed title is taken from. The original title is not
+    /// affected: it is always the romaji title, that being the Japanese title of the anime in
+    /// the alphabet the rest of the world reads it in.
+    /// </summary>
     public TitlePreferenceType TitlePreference { get; set; }
-
-    public TitlePreferenceType OriginalTitlePreference { get; set; }
 
     public bool IgnoreSeason { get; set; }
 

--- a/Jellyfin.Plugin.AniDB/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniDB/Configuration/configPage.html
@@ -9,10 +9,54 @@
         <div id="animeConfigurationPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
             <div data-role="content">
                 <div class="content-primary">
+                    <style>
+                        .anidbNotice { border-left: 0.25em solid #cb272a; padding: 0.6em 1em; margin: 0 0 1.5em 0; background: rgba(203, 39, 42, 0.08); }
                         .anidbInfo { border-left-color: #2256f2; background: rgba(34, 86, 242, 0.08); }
+                        .anidbNotice h3 { margin: 0 0 0.4em 0; }
+                        .anidbNotice p { margin: 0.4em 0; }
+                        .anidbStatus { border: 0.075em solid rgba(127, 127, 127, 0.4); border-radius: 0.25em; padding: 0.6em 1em; margin: 0 0 1.5em 0; }
+                        .anidbStatus h3 { margin: 0 0 0.5em 0; }
+                        .anidbStatusLine { display: flex; align-items: baseline; margin: 0.25em 0; }
+                        .anidbStatusLine dt { flex: 0 0 16em; opacity: 0.7; }
+                        .anidbStatusLine dd { margin: 0; }
+                        .anidbStatusState { font-weight: 600; }
+                        .anidbStatusState-ok { color: #55a655; }
+                        .anidbStatusState-banned { color: #cb272a; }
+                        .anidbStatusCheck { margin: 0.9em 0 0 0; }
+                        .anidbStatusCheck button { margin: 0; }
+                        .anidbStatusCheck .fieldDescription { margin: 0.4em 0 0 0; }
+                        /* Grows with what is typed into it, rather than scrolling a fixed four rows. */
+                        .anidbTextarea { width: 100%; box-sizing: border-box; font-size: 1rem; line-height: 1.4375em; field-sizing: content; min-height: 8em; }
+                    </style>
+
                     <h1>AniDB</h1>
 
+                    <div class="anidbNotice">
                         <h3>AniDB bans clients, addresses and VPNs that ask too often</h3>
+                        <p>AniDB allows one request every few seconds from an IP address and bans one that goes past that, for anything from 15 minutes to a day. The ban is on your address, not on this plugin, so it also stops anything else on the same connection from reaching AniDB.</p>
+                        <p>The first scan of a library is where this is most likely: it asks about every show at once. The plugin paces its requests, waits a ban out rather than retrying into it, and keeps using what it has already cached, so a ban costs you missing metadata for a while rather than anything permanent - refresh those items once it has lifted. It is worth scanning a handful of shows first and letting the rest follow.</p>
+                        <p>Do not lower <em>Maximum Cache Age</em> or <em>Request Interval</em> below their defaults, and raise the interval if anything else on this address talks to AniDB. If a scan seems to have stalled, check the status below before restarting anything: restarting does not clear a ban.</p>
+                    </div>
+
+                    <div class="anidbStatus">
+                        <h3>Status</h3>
+                        <dl id="anidbStatusBody">
+                            <div class="anidbStatusLine"><dt>AniDB</dt><dd id="anidbState">Loading...</dd></div>
+                            <div class="anidbStatusLine"><dt>Requests waiting</dt><dd id="anidbQueued">-</dd></div>
+                            <div class="anidbStatusLine"><dt>Requests sent since start</dt><dd id="anidbSent">-</dd></div>
+                            <div class="anidbStatusLine"><dt>Mapping overrides</dt><dd id="anidbOverrides">-</dd></div>
+                            <div class="anidbStatusLine"><dt>AniBridge mappings</dt><dd id="anidbAniBridge">-</dd></div>
+                            <div class="anidbStatusLine"><dt>Anime list</dt><dd id="anidbAnimeList">-</dd></div>
+                        </dl>
+                        <div class="anidbStatusCheck">
+                            <button id="btnCheckSources" is="emby-button" type="button" class="raised emby-button">
+                                <span>Check For Updates Now</span>
+                            </button>
+                            <div class="fieldDescription">Asks both downloaded sources what they hold now, whatever the age of the copies cached, and downloads whichever has changed. Neither comes from AniDB, so this cannot get your address banned. The overrides need no check: they are read from disk every few seconds while this page is open.</div>
+                            <div class="fieldDescription anidbStatusState" id="anidbCheckResult"></div>
+                        </div>
+                    </div>
+
                     <form id="animeConfigurationForm">
                         <div class="selectContainer">
                             <label class="selectLabel" for="titleLanguage">Title Language</label>
@@ -29,14 +73,21 @@
                             <div class="fieldDescription">Set this to zero to only automatically match if the title of the show is exactly the same. A value of one means that one character can be inserted or deleted.</div>
                         </div>
                         <div class="anidbNotice anidbInfo">
-                            <div class="fieldDescription">AniDB has no seasons: each one is a separate anime entry, and how those divide up is not how the provider numbering your seasons divides them. One entry can be four seasons of a long-running show, a season can end part way into one entry and finish in the next, and a film can sit among the specials. Which entry fills which season is therefore read from the community anime list, downloaded from GitHub once a week and kept in the plugin's cache. A show the list does not carry falls back to working the mapping out from AniDB's own relations and air dates.</div>
+                            <div class="fieldDescription">AniDB has no seasons: each one is a separate anime entry, and how those divide up is not how the provider numbering your seasons divides them. One entry can be four seasons of a long-running show, a season can end part way into one entry and finish in the next, and a movie can sit among the specials. Which entry fills which season is therefore read from the community anime list, which is checked against GitHub once a week, downloaded again only where it has changed since, and kept in the plugin's cache. A show the list does not carry falls back to working the mapping out from AniDB's own relations and air dates.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
                                 <input id="chkIgnoreSeason" name="chkIgnoreSeason" type="checkbox" is="emby-checkbox" />
                                 <span>Ignore Season</span>
                             </label>
-                            <div class="fieldDescription">Use the series' own AniDB entry for every season, numbering episodes straight through. This overrides the mapping described above, so it is only worth setting for a show the anime list places wrongly or does not carry at all - a long-running show kept as one AniDB entry, such as One Piece, no longer needs it. Leave unchecked to give each season the AniDB entry that belongs to it.</div>
+                            <div class="fieldDescription">Use the series' own AniDB entry for every season, numbering episodes straight through. This overrides the mapping described above, so it is only worth setting for a show the mapping sources place wrongly or do not carry at all - a long-running show kept as one AniDB entry, such as One Piece, no longer needs it. Leave unchecked to give each season the AniDB entry that belongs to it.</div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkUseAniBridgeMappings" name="chkUseAniBridgeMappings" type="checkbox" is="emby-checkbox" />
+                                <span>Use The AniBridge Mappings</span>
+                            </label>
+                            <div class="fieldDescription">Consult the AniBridge mappings before the anime list when working out which AniDB entry fills a season. They place half again as many entries, state each season's episode ranges outright rather than leaving them to be worked out from an offset, and are the only source here that can identify a show from its TMDB id, which matters because Jellyfin takes TMDB as the provider for shows by default. The anime list still answers for whatever they do not place. Uncheck to leave the anime list to place everything, which is worth doing only where the mappings place one of your shows wrongly.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
@@ -92,7 +143,7 @@
                         </div>
                         <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="txtTagBlacklist">Tag Blacklist</label>
-                            <textarea id="txtTagBlacklist" name="txtTagBlacklist" is="emby-textarea" class="emby-textarea" rows="4"></textarea>
+                            <textarea id="txtTagBlacklist" name="txtTagBlacklist" is="emby-textarea" class="emby-textarea anidbTextarea" rows="4"></textarea>
                             <div class="fieldDescription">Tag names never to import, one per line or separated by commas. Matched whole and without regard to case, against the name AniDB uses.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
@@ -138,6 +189,133 @@
             <script type="text/javascript">
                 var AniDBConfigurationPage = {
                     pluginUniqueId: "a2b2a7ed-aa28-4521-a64a-63d86901f246",
+                    statusTimer: null,
+
+                    formatDuration: function (seconds) {
+                        var total = Math.max(0, Math.round(seconds));
+
+                        if (total < 60) {
+                            return total + ' seconds';
+                        }
+
+                        if (total < 3600) {
+                            return Math.round(total / 60) + ' minutes';
+                        }
+
+                        return (total / 3600).toFixed(1) + ' hours';
+                    },
+
+                    formatDate: function (value) {
+                        return value ? new Date(value).toLocaleString() : 'never';
+                    },
+
+                    /* Both dates, the check only where it is later than the download: a
+                       check that finds the cached copy current is what leaves the two apart. */
+                    formatSource: function (cachedAtUtc, checkedAtUtc, entryCount, maxAgeDays) {
+                        if (!cachedAtUtc) {
+                            return 'not downloaded yet';
+                        }
+
+                        var text = 'downloaded ' + AniDBConfigurationPage.formatDate(cachedAtUtc);
+
+                        if (checkedAtUtc && new Date(checkedAtUtc) > new Date(cachedAtUtc)) {
+                            text += ', unchanged when checked ' + AniDBConfigurationPage.formatDate(checkedAtUtc);
+                        }
+
+                        return text + ', ' + entryCount + ' entries read, checked again every '
+                            + maxAgeDays + ' days';
+                    },
+
+                    formatCount: function (count, singular, plural) {
+                        return count + ' ' + (count === 1 ? singular : plural);
+                    },
+
+                    formatOverrides: function (status) {
+                        if (!status.OverridesWrittenAtUtc) {
+                            return 'none - write ' + status.OverridesPath + ' to place what the sources below cannot';
+                        }
+
+                        var written = 'written ' + AniDBConfigurationPage.formatDate(status.OverridesWrittenAtUtc);
+
+                        if (status.OverridesError) {
+                            return written + ', but it is not valid JSON and nothing new is taken from it: '
+                                + status.OverridesError;
+                        }
+
+                        return written + ', ' + AniDBConfigurationPage.formatCount(status.OverridesEntryCount, 'entry', 'entries')
+                            + ' read from ' + status.OverridesPath + ', filling '
+                            + AniDBConfigurationPage.formatCount(status.OverridesShowCount, 'show', 'shows')
+                            + ' and identifying '
+                            + AniDBConfigurationPage.formatCount(status.OverridesMovieCount, 'movie', 'movies');
+                    },
+
+                    renderStatus: function (status) {
+                        var state = document.getElementById('anidbState');
+
+                        if (status.IsBanned) {
+                            state.className = 'anidbStatusState anidbStatusState-banned';
+                            state.textContent = 'Paused - AniDB is refusing requests. Waiting '
+                                + AniDBConfigurationPage.formatDuration(status.BanRemainingSeconds)
+                                + ' before trying again. Cached metadata is still used in the meantime.';
+                        } else {
+                            state.className = 'anidbStatusState anidbStatusState-ok';
+                            state.textContent = 'Answering requests, one every '
+                                + (status.RequestIntervalMs / 1000).toFixed(1) + ' seconds.';
+                        }
+
+                        document.getElementById('anidbQueued').textContent = status.QueuedRequests === 0
+                            ? 'none'
+                            : status.QueuedRequests + ' waiting, next in '
+                                + AniDBConfigurationPage.formatDuration(status.NextRequestInSeconds);
+
+                        document.getElementById('anidbSent').textContent = status.RequestsSent
+                            + ' (last ' + AniDBConfigurationPage.formatDate(status.LastRequestUtc) + ')';
+
+                        document.getElementById('anidbOverrides').textContent = AniDBConfigurationPage.formatOverrides(status);
+
+                        document.getElementById('anidbAniBridge').textContent = !status.AniBridgeEnabled
+                            ? 'not used'
+                            : AniDBConfigurationPage.formatSource(
+                                status.AniBridgeCachedAtUtc,
+                                status.AniBridgeCheckedAtUtc,
+                                status.AniBridgeEntryCount,
+                                status.AniBridgeMaxAgeDays);
+
+                        document.getElementById('anidbAnimeList').textContent = AniDBConfigurationPage.formatSource(
+                            status.AnimeListCachedAtUtc,
+                            status.AnimeListCheckedAtUtc,
+                            status.AnimeListEntryCount,
+                            status.AnimeListMaxAgeDays);
+                    },
+
+                    checkSources: function () {
+                        var button = document.getElementById('btnCheckSources');
+                        var result = document.getElementById('anidbCheckResult');
+
+                        button.disabled = true;
+                        result.textContent = 'Checking both sources...';
+
+                        ApiClient.ajax({
+                            type: 'POST',
+                            url: ApiClient.getUrl('AniDB/Sources/Check'),
+                            dataType: 'json'
+                        }).then(function (check) {
+                            button.disabled = false;
+                            result.textContent = 'AniBridge mappings: ' + check.AniBridge
+                                + '. Anime list: ' + check.AnimeList + '.';
+                            AniDBConfigurationPage.refreshStatus();
+                        }, function () {
+                            button.disabled = false;
+                            result.textContent = 'The check could not be run. Restart the server if the plugin was just installed or updated.';
+                        });
+                    },
+
+                    refreshStatus: function () {
+                        ApiClient.getJSON(ApiClient.getUrl('AniDB/Status'))
+                            .then(AniDBConfigurationPage.renderStatus, function () {
+                                document.getElementById('anidbState').textContent = 'Unavailable. Restart the server if the plugin was just installed or updated.';
+                            });
+                    },
 
                     loadConfiguration: function () {
                         Dashboard.showLoadingMsg();
@@ -145,6 +323,7 @@
                         ApiClient.getPluginConfiguration(AniDBConfigurationPage.pluginUniqueId).then(function (config) {
                             document.getElementById('titleLanguage').value = config.TitlePreference;
                             document.getElementById('chkIgnoreSeason').checked = config.IgnoreSeason;
+                            document.getElementById('chkUseAniBridgeMappings').checked = config.UseAniBridgeMappings;
                             document.getElementById('chkUseAniDbSeasonNames').checked = config.UseAniDbSeasonNames;
                             document.getElementById('chkImportGenres').checked = config.ImportGenres;
                             document.getElementById('chkImportTags').checked = config.ImportTags;
@@ -171,6 +350,7 @@
                         ApiClient.getPluginConfiguration(AniDBConfigurationPage.pluginUniqueId).then(function (config) {
                             config.TitlePreference = document.getElementById('titleLanguage').value;
                             config.IgnoreSeason = document.getElementById('chkIgnoreSeason').checked;
+                            config.UseAniBridgeMappings = document.getElementById('chkUseAniBridgeMappings').checked;
                             config.UseAniDbSeasonNames = document.getElementById('chkUseAniDbSeasonNames').checked;
                             config.ImportGenres = document.getElementById('chkImportGenres').checked;
                             config.ImportTags = document.getElementById('chkImportTags').checked;
@@ -196,6 +376,17 @@
 
                 document.getElementById('animeConfigurationPage').addEventListener('pageshow', function () {
                     AniDBConfigurationPage.loadConfiguration();
+                    AniDBConfigurationPage.refreshStatus();
+                    AniDBConfigurationPage.statusTimer = setInterval(AniDBConfigurationPage.refreshStatus, 5000);
+                });
+
+                document.getElementById('animeConfigurationPage').addEventListener('pagehide', function () {
+                    clearInterval(AniDBConfigurationPage.statusTimer);
+                    AniDBConfigurationPage.statusTimer = null;
+                });
+
+                document.getElementById('btnCheckSources').addEventListener('click', function () {
+                    AniDBConfigurationPage.checkSources();
                 });
 
                 document.getElementById('animeConfigurationForm').addEventListener('submit', function (e) {

--- a/Jellyfin.Plugin.AniDB/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniDB/Configuration/configPage.html
@@ -31,12 +31,36 @@
                             <input id="chkTitleSimilarityThreshold" name="chkTitleSimilarityThreshold" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">Set this to zero to only automatically match if the title of the show is exactly the same. A value of one means that one character can be inserted or deleted.</div>
                         </div>
+                        <div class="inputContainer">
+                            <div class="fieldDescription">AniDB has no seasons: each one is a separate anime entry, and how those divide up is not how the provider numbering your seasons divides them. One entry can be four seasons of a long-running show, a season can end part way into one entry and finish in the next, and a film can sit among the specials. Which entry fills which season is therefore read from the community anime list, downloaded from GitHub once a week and kept in the plugin's cache. A show the list does not carry falls back to working the mapping out from AniDB's own relations and air dates.</div>
+                        </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
                                 <input id="chkIgnoreSeason" name="chkIgnoreSeason" type="checkbox" is="emby-checkbox" />
                                 <span>Ignore Season</span>
                             </label>
-                            <div class="fieldDescription">AniDB doesn't support seasons. If checked, it will treat every season like season one, except for specials.</div>
+                            <div class="fieldDescription">Use the series' own AniDB entry for every season, numbering episodes straight through. This overrides the mapping described above, so it is only worth setting for a show the anime list places wrongly or does not carry at all - a long-running show kept as one AniDB entry, such as One Piece, no longer needs it. Leave unchecked to give each season the AniDB entry that belongs to it.</div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkUseAniDbSeasonNames" name="chkUseAniDbSeasonNames" type="checkbox" is="emby-checkbox" />
+                                <span>Name Seasons After Their AniDB Entry</span>
+                            </label>
+                            <div class="fieldDescription">AniDB gives every season of a show its own entry, with its own title. If checked, a season is named after the entry it was filled from. Uncheck to keep the plain "Season 2" naming that the other metadata providers leave behind.</div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkImportGenres" name="chkImportGenres" type="checkbox" is="emby-checkbox" />
+                                <span>Import Genres</span>
+                            </label>
+                            <div class="fieldDescription">Uncheck to take no genres from AniDB at all, leaving the genre list to whichever other provider fills it. AniDB derives genres from its tags, which are far more specific than a genre list usually is.</div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkImportTags" name="chkImportTags" type="checkbox" is="emby-checkbox" />
+                                <span>Import Tags</span>
+                            </label>
+                            <div class="fieldDescription">Uncheck to take no tags from AniDB. Independent of the genres above: a library can have AniDB's tags without its genres, or the other way round.</div>
                         </div>
                         <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>
@@ -48,12 +72,38 @@
                                 <input id="chkTitleCaseGenres" name="chkTitleCaseGenres" type="checkbox" is="emby-checkbox" />
                                 <span>Title Case Genres</span>
                             </label>
+                            <div class="fieldDescription">AniDB writes its tags in lower case. If checked, both genres and tags are capitalised for display.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
                                 <input id="chkTidyGenres" name="chkTidyGenres" type="checkbox" is="emby-checkbox" />
                                 <span>Tidy Genre List</span>
                             </label>
+                            <div class="fieldDescription">AniDB has thousands of tags, most of which name a plot element or a production detail rather than a genre. If checked, only the tags that name a genre are shown as genres, under common genre names. If unchecked, every tag AniDB rates highly enough becomes a genre. Either way the tags themselves are unaffected - use Import Tags above to turn those off.</div>
+                        </div>
+                        <div class="inputContainer">
+                            <label class="inputeLabel inputLabelUnfocused" for="chkMinimumTagWeight">Minimum Tag Weight</label>
+                            <input id="chkMinimumTagWeight" name="chkMinimumTagWeight" type="number" is="emby-input" min="0" />
+                            <div class="fieldDescription">AniDB weights every tag by how much of the show it describes. Tags below this weight are dropped, tags and genres alike. 400 is where AniDB itself stops treating a tag as descriptive; raise it to keep only what characterises the show.</div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkInfoboxTagsOnly" name="chkInfoboxTagsOnly" type="checkbox" is="emby-checkbox" />
+                                <span>Infobox Tags Only</span>
+                            </label>
+                            <div class="fieldDescription">AniDB marks the handful of tags it shows in the infobox on an anime's page. If checked, only those are imported, leaving out the tags that describe the setting, the cast or a production detail.</div>
+                        </div>
+                        <div class="inputContainer">
+                            <label class="inputeLabel inputLabelUnfocused" for="txtTagBlacklist">Tag Blacklist</label>
+                            <textarea id="txtTagBlacklist" name="txtTagBlacklist" is="emby-textarea" class="emby-textarea" rows="4"></textarea>
+                            <div class="fieldDescription">Tag names never to import, one per line or separated by commas. Matched whole and without regard to case, against the name AniDB uses.</div>
+                        </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkIncludeAdultTags" name="chkIncludeAdultTags" type="checkbox" is="emby-checkbox" />
+                                <span>Include Adult Tags</span>
+                            </label>
+                            <div class="fieldDescription">AniDB flags 125 of its tags as 18+ content, naming sexual acts and body parts in detail. Those are dropped, along with anything filed under them, unless this is checked. Anime AniDB flags as adult are rated as such either way, so parental controls are unaffected by this setting.</div>
                         </div>
                         <div class="selectContainer">
                             <label class="selectLabel" for="animeDefaultGenre">Anime Default Genre Name</label>
@@ -67,6 +117,11 @@
                             <label class="inputeLabel inputLabelUnfocused" for="chkMaxCacheAge">Maximum Cache Age</label>
                             <input id="chkMaxCacheAge" name="chkMaxCacheAge" type="number" is="emby-input" min="7" />
                             <div class="fieldDescription">How many days cached series metadata will be reused before fetching new metatdata from AniDB. Minimum 7 days: AniDB allows only a low number of requests per IP per day, and shorter windows will get your server banned.</div>
+                        </div>
+                        <div class="inputContainer">
+                            <label class="inputeLabel inputLabelUnfocused" for="chkRequestIntervalMs">Request Interval (ms)</label>
+                            <input id="chkRequestIntervalMs" name="chkRequestIntervalMs" type="number" is="emby-input" min="2500" step="100" />
+                            <div class="fieldDescription">How long to wait between two AniDB requests. Minimum 2500 ms, which is what AniDB itself allows. AniDB counts requests per IP rather than per client, so raise this if anything else on the same address talks to AniDB as well.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
@@ -94,13 +149,21 @@
                             document.getElementById('titleLanguage').value = config.TitlePreference;
                             document.getElementById('originalTitleLanguage').value = config.OriginalTitlePreference;
                             document.getElementById('chkIgnoreSeason').checked = config.IgnoreSeason;
+                            document.getElementById('chkUseAniDbSeasonNames').checked = config.UseAniDbSeasonNames;
+                            document.getElementById('chkImportGenres').checked = config.ImportGenres;
+                            document.getElementById('chkImportTags').checked = config.ImportTags;
                             document.getElementById('chkTitleSimilarityThreshold').value = config.TitleSimilarityThreshold;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
                             document.getElementById('chkTitleCaseGenres').checked = config.TitleCaseGenres;
                             document.getElementById('chkTidyGenres').checked = config.TidyGenreList;
                             document.getElementById('animeDefaultGenre').value = config.AnimeDefaultGenre;
                             document.getElementById('chkMaxCacheAge').value = config.MaxCacheAge;
+                            document.getElementById('chkRequestIntervalMs').value = config.RequestIntervalMs;
                             document.getElementById('chkAniDbReplaceGraves').checked = config.AniDbReplaceGraves;
+                            document.getElementById('chkIncludeAdultTags').checked = config.IncludeAdultTags;
+                            document.getElementById('chkMinimumTagWeight').value = config.MinimumTagWeight;
+                            document.getElementById('chkInfoboxTagsOnly').checked = config.InfoboxTagsOnly;
+                            document.getElementById('txtTagBlacklist').value = config.TagBlacklist;
 
                             Dashboard.hideLoadingMsg();
                         });
@@ -113,13 +176,21 @@
                             config.TitlePreference = document.getElementById('titleLanguage').value;
                             config.OriginalTitlePreference = document.getElementById('originalTitleLanguage').value;
                             config.IgnoreSeason = document.getElementById('chkIgnoreSeason').checked;
+                            config.UseAniDbSeasonNames = document.getElementById('chkUseAniDbSeasonNames').checked;
+                            config.ImportGenres = document.getElementById('chkImportGenres').checked;
+                            config.ImportTags = document.getElementById('chkImportTags').checked;
                             config.TitleSimilarityThreshold = document.getElementById('chkTitleSimilarityThreshold').value;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
                             config.TitleCaseGenres = document.getElementById('chkTitleCaseGenres').checked;
                             config.TidyGenreList = document.getElementById('chkTidyGenres').checked;
                             config.AnimeDefaultGenre = document.getElementById('animeDefaultGenre').value;
                             config.MaxCacheAge = document.getElementById('chkMaxCacheAge').value;
+                            config.RequestIntervalMs = document.getElementById('chkRequestIntervalMs').value;
                             config.AniDbReplaceGraves = document.getElementById('chkAniDbReplaceGraves').checked;
+                            config.IncludeAdultTags = document.getElementById('chkIncludeAdultTags').checked;
+                            config.MinimumTagWeight = document.getElementById('chkMinimumTagWeight').value;
+                            config.InfoboxTagsOnly = document.getElementById('chkInfoboxTagsOnly').checked;
+                            config.TagBlacklist = document.getElementById('txtTagBlacklist').value;
 
                             ApiClient.updatePluginConfiguration(AniDBConfigurationPage.pluginUniqueId, config).then(function (result) {
                                 Dashboard.processPluginConfigurationUpdateResult(result);

--- a/Jellyfin.Plugin.AniDB/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniDB/Configuration/configPage.html
@@ -9,6 +9,10 @@
         <div id="animeConfigurationPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
             <div data-role="content">
                 <div class="content-primary">
+                        .anidbInfo { border-left-color: #2256f2; background: rgba(34, 86, 242, 0.08); }
+                    <h1>AniDB</h1>
+
+                        <h3>AniDB bans clients, addresses and VPNs that ask too often</h3>
                     <form id="animeConfigurationForm">
                         <div class="selectContainer">
                             <label class="selectLabel" for="titleLanguage">Title Language</label>
@@ -17,21 +21,14 @@
                                 <option id="optLanguageJapanese" value="Japanese">Japanese</option>
                                 <option id="optLanguageJapaneseRomaji" value="JapaneseRomaji">Romaji</option>
                             </select>
-                        </div>
-                        <div class="selectContainer">
-                            <label class="selectLabel" for="originalTitleLanguage">Original Title Language</label>
-                            <select is="emby-select" id="originalTitleLanguage" name="originalTitleLanguage" class="emby-select-withcolor emby-select">
-                                <option id="optLanguageLocalized" value="Localized">Localized</option>
-                                <option id="optLanguageJapanese" value="Japanese">Japanese</option>
-                                <option id="optLanguageJapaneseRomaji" value="JapaneseRomaji">Romaji</option>
-                            </select>
+                            <div class="fieldDescription">The language the displayed title is taken from, falling back to the official English title and only then to the romaji one, so that a displayed title is in the Latin alphabet wherever AniDB has one. The original title is always the romaji title.</div>
                         </div>
                         <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="chkTitleSimilarityThreshold">Title Similarity Threshold</label>
                             <input id="chkTitleSimilarityThreshold" name="chkTitleSimilarityThreshold" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">Set this to zero to only automatically match if the title of the show is exactly the same. A value of one means that one character can be inserted or deleted.</div>
                         </div>
-                        <div class="inputContainer">
+                        <div class="anidbNotice anidbInfo">
                             <div class="fieldDescription">AniDB has no seasons: each one is a separate anime entry, and how those divide up is not how the provider numbering your seasons divides them. One entry can be four seasons of a long-running show, a season can end part way into one entry and finish in the next, and a film can sit among the specials. Which entry fills which season is therefore read from the community anime list, downloaded from GitHub once a week and kept in the plugin's cache. A show the list does not carry falls back to working the mapping out from AniDB's own relations and air dates.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
@@ -46,14 +43,14 @@
                                 <input id="chkUseAniDbSeasonNames" name="chkUseAniDbSeasonNames" type="checkbox" is="emby-checkbox" />
                                 <span>Name Seasons After Their AniDB Entry</span>
                             </label>
-                            <div class="fieldDescription">AniDB gives every season of a show its own entry, with its own title. If checked, a season is named after the entry it was filled from. Uncheck to keep the plain "Season 2" naming that the other metadata providers leave behind.</div>
+                            <div class="fieldDescription">AniDB gives every season of a show its own entry, with its own title, which for an arc usually carries the show's title as well and is longer than a season list has room for. If checked, a season is named after the entry it was filled from. Uncheck to keep the plain "Season 2" naming that the other metadata providers leave behind.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
                                 <input id="chkImportGenres" name="chkImportGenres" type="checkbox" is="emby-checkbox" />
                                 <span>Import Genres</span>
                             </label>
-                            <div class="fieldDescription">Uncheck to take no genres from AniDB at all, leaving the genre list to whichever other provider fills it. AniDB derives genres from its tags, which are far more specific than a genre list usually is.</div>
+                            <div class="fieldDescription">Uncheck to take no genres from AniDB at all, leaving the genre list to whichever other provider fills it. AniDB derives genres from its tags, which are far more specific than a genre list usually is and do not line up with the genres the other providers give.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
@@ -84,7 +81,7 @@
                         <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="chkMinimumTagWeight">Minimum Tag Weight</label>
                             <input id="chkMinimumTagWeight" name="chkMinimumTagWeight" type="number" is="emby-input" min="0" />
-                            <div class="fieldDescription">AniDB weights every tag by how much of the show it describes. Tags below this weight are dropped, tags and genres alike. 400 is where AniDB itself stops treating a tag as descriptive; raise it to keep only what characterises the show.</div>
+                            <div class="fieldDescription">AniDB weights every tag by how much of the show it describes. Tags below this weight are dropped, tags and genres alike. 400 is where AniDB itself stops treating a tag as descriptive; raise it to keep only what characterises the show. AniDB weights a tag from 0 to 600 in steps of 100 - see <a is="emby-linkbutton" class="button-link" target="_blank" rel="noopener noreferrer" href="https://wiki.anidb.net/Tags#Star-rating_-_the_Weight_system">the weight system</a> on the AniDB wiki.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
@@ -121,7 +118,7 @@
                         <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="chkRequestIntervalMs">Request Interval (ms)</label>
                             <input id="chkRequestIntervalMs" name="chkRequestIntervalMs" type="number" is="emby-input" min="2500" step="100" />
-                            <div class="fieldDescription">How long to wait between two AniDB requests. Minimum 2500 ms, which is what AniDB itself allows. AniDB counts requests per IP rather than per client, so raise this if anything else on the same address talks to AniDB as well.</div>
+                            <div class="fieldDescription">How long to wait between two AniDB requests. Minimum 2500 ms, which is what AniDB itself allows. AniDB counts requests per IP rather than per client, so raise this if anything else on the same address talks to AniDB as well. One request covers a whole entry, and probing the files of a season usually takes longer than the wait does, so a higher interval costs a scan less than it looks like it would.</div>
                         </div>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
@@ -147,7 +144,6 @@
 
                         ApiClient.getPluginConfiguration(AniDBConfigurationPage.pluginUniqueId).then(function (config) {
                             document.getElementById('titleLanguage').value = config.TitlePreference;
-                            document.getElementById('originalTitleLanguage').value = config.OriginalTitlePreference;
                             document.getElementById('chkIgnoreSeason').checked = config.IgnoreSeason;
                             document.getElementById('chkUseAniDbSeasonNames').checked = config.UseAniDbSeasonNames;
                             document.getElementById('chkImportGenres').checked = config.ImportGenres;
@@ -174,7 +170,6 @@
 
                         ApiClient.getPluginConfiguration(AniDBConfigurationPage.pluginUniqueId).then(function (config) {
                             config.TitlePreference = document.getElementById('titleLanguage').value;
-                            config.OriginalTitlePreference = document.getElementById('originalTitleLanguage').value;
                             config.IgnoreSeason = document.getElementById('chkIgnoreSeason').checked;
                             config.UseAniDbSeasonNames = document.getElementById('chkUseAniDbSeasonNames').checked;
                             config.ImportGenres = document.getElementById('chkImportGenres').checked;

--- a/Jellyfin.Plugin.AniDB/Plugin.cs
+++ b/Jellyfin.Plugin.AniDB/Plugin.cs
@@ -78,13 +78,13 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()
     {
-        return new[]
-        {
+        return
+        [
             new PluginPageInfo
             {
                 Name = Name,
                 EmbeddedResourcePath = GetType().Namespace + ".Configuration.configPage.html"
             }
-        };
+        ];
     }
 }

--- a/Jellyfin.Plugin.AniDB/Plugin.cs
+++ b/Jellyfin.Plugin.AniDB/Plugin.cs
@@ -46,8 +46,8 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         Instance = this;
         _httpClientFactory = httpClientFactory;
 
-        // The AniDB ban state is global to the plugin, so its logger has to be too. The
-        // logger must be in place before the ban is restored, or the warning is lost.
+        // Ban state is global to the plugin, so its logger has to be too, and has to be set
+        // before the ban is restored or the warning is lost.
         AniDbSeriesProvider.Logger = seriesLogger;
         AniDbSeriesProvider.RestoreBanState(Configuration);
 

--- a/Jellyfin.Plugin.AniDB/Plugin.cs
+++ b/Jellyfin.Plugin.AniDB/Plugin.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using Jellyfin.Plugin.AniDB.Configuration;
 using Jellyfin.Plugin.AniDB.Providers.AniDB.Identity;
 using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 using MediaBrowser.Common.Configuration;
-using MediaBrowser.Common.Net;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
@@ -19,9 +17,11 @@ namespace Jellyfin.Plugin.AniDB;
 /// </summary>
 public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
-    // Identify the plugin rather than the service it talks to: AniDB bans by client, so the
-    // header should say what this actually is. Built once, since it never varies.
-    private static readonly ProductInfoHeaderValue _userAgentProduct = new("jellyfin-plugin-anidb", ResolveVersion());
+    /// <summary>
+    /// The name of the HTTP client <see cref="PluginServiceRegistrator"/> registers with the
+    /// plugin's user agent, and that every AniDB request is sent with.
+    /// </summary>
+    public const string HttpClientName = "AniDB";
 
     private readonly IHttpClientFactory _httpClientFactory;
 
@@ -73,27 +73,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     /// <returns>The configured <see cref="HttpClient"/>.</returns>
     public HttpClient GetHttpClient()
-    {
-        var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
-        httpClient.DefaultRequestHeaders.UserAgent.Add(_userAgentProduct);
-
-        return httpClient;
-    }
-
-    /// <summary>
-    /// Resolves the plugin version for the user agent. The assembly version is used rather
-    /// than the informational version because the latter may carry a build metadata suffix,
-    /// which is not a legal product version token and would throw when parsed.
-    /// </summary>
-    /// <returns>The plugin version.</returns>
-    private static string ResolveVersion()
-    {
-        var version = typeof(Plugin).Assembly.GetName().Version;
-
-        return version is null
-            ? "0.0.0.0"
-            : version.ToString();
-    }
+        => _httpClientFactory.CreateClient(HttpClientName);
 
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()

--- a/Jellyfin.Plugin.AniDB/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.AniDB/PluginServiceRegistrator.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Mime;
+using System.Text;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jellyfin.Plugin.AniDB;
+
+/// <summary>
+/// Registers the <see cref="HttpClient"/> every AniDB request is sent with.
+/// </summary>
+public class PluginServiceRegistrator : IPluginServiceRegistrator
+{
+    /// <inheritdoc />
+    public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
+    {
+        ArgumentNullException.ThrowIfNull(applicationHost);
+
+        serviceCollection.AddHttpClient(Plugin.HttpClientName, client =>
+            {
+                client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(
+                    applicationHost.Name.Replace(' ', '-'),
+                    applicationHost.ApplicationVersionString));
+                client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(
+                    "jellyfin-plugin-anidb",
+                    ResolveVersion()));
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Xml, 0.9));
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*", 0.8));
+            })
+            // Mirrors the handler Jellyfin configures for its own named clients, which a plugin
+            // client does not inherit. The titles dump is fetched as a gzip file and unpacked by
+            // hand, so it depends on this matching what the default client used to do.
+            .ConfigurePrimaryHttpMessageHandler(_ => new SocketsHttpHandler
+            {
+                AutomaticDecompression = DecompressionMethods.All,
+                RequestHeaderEncodingSelector = (_, _) => Encoding.UTF8
+            });
+    }
+
+    /// <summary>
+    /// Resolves the plugin version for the user agent. The assembly version is used because
+    /// the informational version may carry a build metadata suffix, which is not a legal
+    /// product version token and throws when parsed.
+    /// </summary>
+    /// <returns>The plugin version.</returns>
+    private static string ResolveVersion()
+    {
+        var version = typeof(Plugin).Assembly.GetName().Version;
+
+        return version is null
+            ? "0.0.0.0"
+            : version.ToString();
+    }
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/AniDbExternalPersonId.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/AniDbExternalPersonId.cs
@@ -1,0 +1,28 @@
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB;
+
+/// <summary>
+/// The AniDB external id for people.
+/// </summary>
+public class AniDbExternalPersonId : IExternalId
+{
+    /// <inheritdoc />
+    public string ProviderName
+        => "AniDB";
+
+    /// <inheritdoc />
+    public string Key
+        => ProviderNames.AniDb;
+
+    /// <inheritdoc />
+    public ExternalIdMediaType? Type
+        => ExternalIdMediaType.Person;
+
+    /// <inheritdoc />
+    public bool Supports(IHasProviderIds item)
+        => item is Person;
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/AniDbExternalSeasonId.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/AniDbExternalSeasonId.cs
@@ -6,9 +6,9 @@ using MediaBrowser.Model.Providers;
 namespace Jellyfin.Plugin.AniDB.Providers.AniDB;
 
 /// <summary>
-/// The AniDB external id for episodes.
+/// The AniDB external id for seasons.
 /// </summary>
-public class AniDbExternalEpisodeId : IExternalId
+public class AniDbExternalSeasonId : IExternalId
 {
     /// <inheritdoc />
     public string ProviderName
@@ -20,9 +20,9 @@ public class AniDbExternalEpisodeId : IExternalId
 
     /// <inheritdoc />
     public ExternalIdMediaType? Type
-        => ExternalIdMediaType.Episode;
+        => ExternalIdMediaType.Season;
 
     /// <inheritdoc />
     public bool Supports(IHasProviderIds item)
-        => item is Episode;
+        => item is Season;
 }

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/AniDbExternalUrlProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/AniDbExternalUrlProvider.cs
@@ -23,6 +23,7 @@ public class AniDbExternalUrlProvider : IExternalUrlProvider
             switch (item)
             {
                 case Series:
+                case Season:
                 case Movie:
                     yield return $"https://anidb.net/anime/{externalId}";
                     break;

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Identity/AniDbTitleDownloader.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Identity/AniDbTitleDownloader.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Identity;
 
 /// <summary>
-/// The AniDbTitleDownloader class downloads the anime titles file from AniDB and stores it.
+/// Downloads the anime titles file from AniDB and stores it.
 /// </summary>
 public class AniDbTitleDownloader : IAniDbTitleDownloader
 {
@@ -76,7 +76,7 @@ public class AniDbTitleDownloader : IAniDbTitleDownloader
         var titlesFile = StaticTitlesFilePath;
         var titlesFileInfo = new FileInfo(titlesFile);
 
-        // download titles if we do not already have them, or have not updated for a week
+        // Download when the file is missing or has not been updated for a week.
         if (!titlesFileInfo.Exists || (DateTime.UtcNow - titlesFileInfo.LastWriteTimeUtc).TotalDays > 7)
         {
             await DownloadTitlesStatic(titlesFile, cancellationToken).ConfigureAwait(false);
@@ -89,7 +89,7 @@ public class AniDbTitleDownloader : IAniDbTitleDownloader
         var titlesFile = TitlesFilePath;
         var titlesFileInfo = new FileInfo(titlesFile);
 
-        // download titles if we do not already have them, or have not updated for a week
+        // Download when the file is missing or has not been updated for a week.
         if (!titlesFileInfo.Exists || (DateTime.UtcNow - titlesFileInfo.LastWriteTimeUtc).TotalDays > 7)
         {
             await DownloadTitles(titlesFile, cancellationToken).ConfigureAwait(false);
@@ -108,14 +108,14 @@ public class AniDbTitleDownloader : IAniDbTitleDownloader
         var httpClient = Plugin.Instance.GetHttpClient();
         await AniDbSeriesProvider.WaitForRequestSlot(cancellationToken).ConfigureAwait(false);
 
-        // Decompress into a temporary file and only swap it in once it is complete. A ban is
-        // answered with a plain <error> document rather than gzip, which would otherwise
-        // truncate the existing titles file that every title lookup depends on.
+        // Decompress into a temporary file and swap it in once complete. A ban is answered
+        // with a plain <error> document rather than gzip, which would otherwise truncate the
+        // titles file every lookup depends on.
         var temporaryFile = titlesFile + ".tmp";
 
         try
         {
-            // The URL for retrieving a list of all anime titles and their AniDB IDs.
+            // Every anime title and its AniDB id.
             using (var stream = await httpClient.GetStreamAsync(new Uri("https://anidb.net/api/anime-titles.xml.gz"), cancellationToken).ConfigureAwait(false))
             using (var unzipped = new GZipStream(stream, CompressionMode.Decompress))
             using (var writer = File.Open(temporaryFile, FileMode.Create, FileAccess.Write))

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Identity/AniDbTitleMatcher.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Identity/AniDbTitleMatcher.cs
@@ -11,8 +11,8 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Identity;
 
 /// <summary>
-/// The <see cref="AniDbTitleMatcher"/> class loads series titles from the series.xml file in the application data anidb folder,
-/// and provides the means to search for a the AniDB of a series by series title.
+/// Loads series titles from the titles file in the application data anidb folder and searches
+/// them for the AniDB id of a series.
 /// </summary>
 /// <remarks>
 /// Initializes a new instance of the <see cref="AniDbTitleMatcher"/> class.
@@ -98,11 +98,11 @@ public sealed class AniDbTitleMatcher(ILogger<AniDbTitleMatcher> logger, IAniDbT
         {
             if (c >= 0x2B0 && c <= 0x0333)
             {
-                // skip char modifier and diacritics
+                // Skip character modifiers and diacritics.
             }
             else if ("\"'!`?".Contains(c, StringComparison.Ordinal))
             {
-                // skip chars we are removing
+                // Skip the characters being removed.
             }
             else if ("/,.:;\\(){}[]+-_=–*".Contains(c, StringComparison.Ordinal)) // (there are not actually two - in the they are different char codes)
             {

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeEntry.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeEntry.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// One AniDB anime as the AniBridge mappings place it: which show it belongs to, and span by
+/// span, which of its episodes fill which episodes of which season of that show.
+/// </summary>
+/// <param name="AnimeId">The AniDB id of the entry.</param>
+/// <param name="SeriesKey">The TVDB series id the entry's episodes are placed against. No entry in the set is placed against more than one.</param>
+/// <param name="Spans">Where the entry's episodes go, in the order they were read.</param>
+internal sealed record AniBridgeEntry(
+    string AnimeId,
+    string SeriesKey,
+    IReadOnlyList<AniBridgeSpan> Spans);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeIndex.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeIndex.cs
@@ -1,0 +1,867 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// The AniBridge mappings, as read from one downloaded copy of them.
+/// </summary>
+internal sealed class AniBridgeIndex
+{
+    /// <summary>
+    /// The schema this understands. The download URL pins the same major version, so a mapping
+    /// set that has moved on is a set this would read wrongly rather than not at all, and is
+    /// worth saying so about.
+    /// </summary>
+    private const string SchemaMajorVersion = "3";
+
+    /// <summary>
+    /// Where AniDB's other episodes begin in the single numbering the specials scope uses.
+    /// </summary>
+    private const int OtherEpisodeBand = 400;
+
+    private readonly IReadOnlyDictionary<string, AniBridgeEntry> _byAnimeId;
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<AniBridgeEntry>> _bySeries;
+    private readonly IReadOnlyDictionary<string, string> _firstSeasonByTmdb;
+    private readonly IReadOnlyDictionary<string, AniDbAnimeListEpisode> _movies;
+
+    private AniBridgeIndex(
+        IReadOnlyDictionary<string, AniBridgeEntry> byAnimeId,
+        IReadOnlyDictionary<string, IReadOnlyList<AniBridgeEntry>> bySeries,
+        IReadOnlyDictionary<string, string> firstSeasonByTmdb,
+        IReadOnlyDictionary<string, AniDbAnimeListEpisode> movies)
+    {
+        _byAnimeId = byAnimeId;
+        _bySeries = bySeries;
+        _firstSeasonByTmdb = firstSeasonByTmdb;
+        _movies = movies;
+    }
+
+    /// <summary>
+    /// Gets the placement worked out for every season already asked about, keyed by AniDB
+    /// series id and season number, holding an empty list for a season the mappings do not
+    /// place. Each of a season's episodes asks the same question, and the answer changes only
+    /// when the mappings are read again, which replaces this along with them.
+    /// </summary>
+    public ConcurrentDictionary<string, IReadOnlyList<AniDbSeasonSegment>> Placements { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets how many AniDB entries the mappings place against a TVDB series.
+    /// </summary>
+    public int EntryCount => _byAnimeId.Count;
+
+    /// <summary>
+    /// Gets how many shows the mappings place those entries in. Fewer than the entries wherever
+    /// a show is filed under several of them, which is the ordinary case: a season, its specials
+    /// and the movie released alongside them are three entries of one show.
+    /// </summary>
+    public int ShowCount => _bySeries.Count;
+
+    /// <summary>
+    /// Gets how many movies the mappings identify. Counted by the AniDB episode each names, not
+    /// by the keys they are filed under: one movie is filed under a TMDB, an IMDb and a TVDB id,
+    /// and is one movie.
+    /// </summary>
+    public int MovieCount => _movies.Values.Distinct().Count();
+
+    /// <summary>
+    /// Reads a downloaded copy of the mappings.
+    /// </summary>
+    /// <param name="path">Where the copy is cached.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cachedAtUtc">When the copy was written.</param>
+    /// <param name="description">How the file is named in log messages, as a noun phrase. The schema is read by more than one file: the downloaded mappings, and the overrides written by whoever runs the server.</param>
+    /// <returns>The mappings.</returns>
+    public static AniBridgeIndex Parse(string path, ILogger logger, DateTime cachedAtUtc, string description)
+    {
+        // Read whole rather than streamed. The file is a single object of some seventy thousand
+        // keys, all but the AniDB ones skipped, so a reader over the bytes costs one buffer the
+        // size of the file and no bookkeeping, where a document object model over it would cost
+        // several times the file and hold every key this throws away.
+        var bytes = File.ReadAllBytes(path);
+        var reader = new Utf8JsonReader(bytes, new JsonReaderOptions { AllowTrailingCommas = true, CommentHandling = JsonCommentHandling.Skip });
+
+        var spans = new Dictionary<string, List<AniBridgeSpan>>(StringComparer.Ordinal);
+        var seriesKeys = new Dictionary<string, string>(StringComparer.Ordinal);
+        var tmdbCandidates = new Dictionary<string, List<SeasonClaim>>(StringComparer.Ordinal);
+        var movies = new Dictionary<string, List<AniDbAnimeListEpisode>>(StringComparer.Ordinal);
+        string? schemaVersion = null;
+
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("The AniBridge mappings do not begin with an object");
+        }
+
+        while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+        {
+            if (reader.ValueSpan.SequenceEqual("$meta"u8))
+            {
+                reader.Read();
+                schemaVersion = ReadSchemaVersion(ref reader);
+
+                continue;
+            }
+
+            // Only the AniDB side of the mappings is read. Every mapping is written in both
+            // directions - all 8,633 AniDB-to-TVDB placements appear as TVDB-to-AniDB ones too
+            // - so the shows keyed the other way are the same shows, and skipping them here
+            // costs nothing but saves reading some sixty thousand keys.
+            if (!reader.ValueSpan.StartsWith("anidb:"u8))
+            {
+                reader.Skip();
+
+                continue;
+            }
+
+            var descriptor = reader.GetString()!;
+
+            reader.Read();
+
+            if (TryReadScope(descriptor, out var animeId, out var kind))
+            {
+                ReadTargets(ref reader, animeId, kind, spans, seriesKeys, tmdbCandidates, movies);
+            }
+            else
+            {
+                reader.Skip();
+            }
+        }
+
+        if (schemaVersion != null && !schemaVersion.StartsWith(SchemaMajorVersion + ".", StringComparison.Ordinal))
+        {
+            logger.LogWarning(
+                "{Source} are written to schema {SchemaVersion}, and this reads schema {SupportedVersion}. Seasons may be placed wrongly until the plugin is updated",
+                description,
+                schemaVersion,
+                SchemaMajorVersion);
+        }
+
+        return Build(spans, seriesKeys, tmdbCandidates, movies, schemaVersion, cachedAtUtc, description, logger);
+    }
+
+    /// <summary>
+    /// Every entry the mappings file under the same show as the given one.
+    /// </summary>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <returns>The entries, or <c>null</c> where the mappings do not place that one.</returns>
+    public IReadOnlyList<AniBridgeEntry>? Siblings(string animeId)
+    {
+        if (!_byAnimeId.TryGetValue(animeId, out var self))
+        {
+            return null;
+        }
+
+        return _bySeries.TryGetValue(self.SeriesKey, out var siblings) ? siblings : null;
+    }
+
+    /// <summary>
+    /// Every entry filed under the given show.
+    /// </summary>
+    /// <param name="seriesKey">The TVDB id the show's seasons are numbered against.</param>
+    /// <returns>The entries, or <c>null</c> where nothing is filed under that show.</returns>
+    public IReadOnlyList<AniBridgeEntry>? EntriesFor(string seriesKey)
+        => _bySeries.GetValueOrDefault(seriesKey);
+
+    /// <summary>
+    /// The show an entry is filed under, as the TVDB id its seasons are numbered against.
+    /// </summary>
+    /// <remarks>
+    /// What a sparsely written set of mappings is reached through. Such a set names the one
+    /// entry it has something to say about, which is rarely the entry a show is identified as,
+    /// so a lookup by that entry finds nothing; the show it belongs to is what the two sets
+    /// have in common.
+    /// </remarks>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <returns>The TVDB id, or <c>null</c> where the mappings do not place that entry.</returns>
+    public string? SeriesKeyOf(string animeId)
+        => _byAnimeId.TryGetValue(animeId, out var entry) ? entry.SeriesKey : null;
+
+    /// <summary>
+    /// Works out which of a show's entries fill the given season, and which of their episodes
+    /// each one contributes.
+    /// </summary>
+    /// <param name="siblings">Every entry the mappings file under the same show.</param>
+    /// <param name="seasonNumber">The season number.</param>
+    /// <returns>The segments, in the order the season's episodes run through them.</returns>
+    public static IReadOnlyList<AniDbSeasonSegment> Place(IReadOnlyList<AniBridgeEntry> siblings, int seasonNumber)
+    {
+        // Kept apart because one entry can describe the same season under two of its own
+        // numberings: anime 13473 maps a single ordinary episode onto season 2 and all twelve of
+        // its other episodes onto the same twelve, the season being three movies that the season
+        // numbering breaks into television episodes. Mixing the two would leave the season
+        // claimed twice over, so the fuller numbering is taken whole and the other dropped.
+        var claims = new Dictionary<AniDbEpisodeKind, List<AniDbSeasonSegment>>();
+
+        foreach (var entry in siblings)
+        {
+            foreach (var span in entry.Spans)
+            {
+                // A season can be filled from any of an entry's numberings, the specials
+                // included: K-On!'s first season ends with two of them, and the segment says so
+                // rather than the episode being left unidentified.
+                if (span.Season != seasonNumber)
+                {
+                    continue;
+                }
+
+                SeasonSegments.Add(claims, new AniDbSeasonSegment(entry.AnimeId, span.InSeason.Start, CountOf(span), span.InEntry.Start, span.Kind));
+            }
+        }
+
+        return SeasonSegments.Resolve(claims);
+    }
+
+    /// <summary>
+    /// The entry a show begins in, found from the TVDB id another provider has already settled
+    /// on.
+    /// </summary>
+    /// <param name="tvdbId">The TVDB series id.</param>
+    /// <returns>The AniDB id, or <c>null</c> where the mappings place nothing against that id.</returns>
+    public string? FirstSeasonByTvdb(string tvdbId)
+        => _bySeries.TryGetValue(tvdbId, out var siblings) ? PickFirstSeason(siblings) : null;
+
+    /// <summary>
+    /// The entry a show begins in, found from the TMDB id another provider has already settled
+    /// on. The anime list cannot answer this: it carries TMDB ids for movies only.
+    /// </summary>
+    /// <param name="tmdbId">The TMDB show id.</param>
+    /// <returns>The AniDB id, or <c>null</c> where the mappings place nothing against that id.</returns>
+    public string? FirstSeasonByTmdb(string tmdbId)
+        => _firstSeasonByTmdb.GetValueOrDefault(tmdbId);
+
+    /// <summary>
+    /// The AniDB entry a movie is, and which of its episodes holds it.
+    /// </summary>
+    /// <param name="key">The movie's key, from <see cref="MovieKey"/>.</param>
+    /// <returns>The episode, or <c>null</c> where the mappings identify no movie under that id.</returns>
+    public AniDbAnimeListEpisode? ResolveMovie(string key)
+        => _movies.GetValueOrDefault(key);
+
+    /// <summary>
+    /// Whether the mappings file the given entry in an ordinary season of a show, which makes
+    /// their silence about walking it back a statement rather than a gap.
+    /// </summary>
+    /// <param name="animeId">The AniDB id of the entry.</param>
+    /// <returns><c>true</c> where the mappings place the entry in a season of its own.</returns>
+    public bool FilesInOrdinarySeason(string animeId)
+        => _byAnimeId.TryGetValue(animeId, out var entry) && SeasonOf(entry) >= 1;
+
+    /// <summary>
+    /// The entry a show begins in, given an entry of it the mappings file as a later season.
+    /// </summary>
+    /// <param name="animeId">The AniDB id the name match produced.</param>
+    /// <returns>The AniDB id the show begins at, or <c>null</c> where the mappings do not place the entry or already place it at the show's first season.</returns>
+    public string? WalkBackToFirstSeason(string animeId)
+    {
+        // Only an entry the mappings file as a second season or later is walked back. An entry
+        // already at season 1 is the show's own start, and moving it could only hand the show
+        // to whatever else shares its TVDB id.
+        if (!_byAnimeId.TryGetValue(animeId, out var self) || SeasonOf(self) <= 1)
+        {
+            return null;
+        }
+
+        var siblings = Siblings(animeId);
+        var first = siblings == null ? null : PickFirstSeason(siblings);
+
+        return string.Equals(first, animeId, StringComparison.Ordinal) ? null : first;
+    }
+
+    /// <summary>
+    /// Where the given episode of the specials season is read from.
+    /// </summary>
+    /// <param name="siblings">Every entry the mappings file under the same show.</param>
+    /// <param name="episodeNumber">The episode number within the specials season.</param>
+    /// <returns>The episode, or <c>null</c> where the mappings do not place it.</returns>
+    public static AniDbAnimeListEpisode? PlaceSpecial(IReadOnlyList<AniBridgeEntry> siblings, int episodeNumber)
+    {
+        AniBridgeEntry? holder = null;
+        AniBridgeSpan? narrowest = null;
+
+        foreach (var entry in siblings)
+        {
+            foreach (var span in entry.Spans)
+            {
+                if (span.Season != 0 || episodeNumber < span.InSeason.Start || episodeNumber > (span.InSeason.End ?? int.MaxValue))
+                {
+                    continue;
+                }
+
+                var number = span.InEntry.Start + (episodeNumber - span.InSeason.Start);
+
+                // The two sides of a span disagree in length here and there, the mappings
+                // reporting some nine thousand such spans themselves. Where they do, an
+                // episode past the end of the entry's own run is not placed by this span.
+                if (number > (span.InEntry.End ?? int.MaxValue))
+                {
+                    continue;
+                }
+
+                // A span naming this episode outright beats one that merely covers it, which
+                // is what places a movie that the season numbering files among the specials.
+                if (narrowest == null || (span.InSeason.Length ?? int.MaxValue) < (narrowest.InSeason.Length ?? int.MaxValue))
+                {
+                    holder = entry;
+                    narrowest = span;
+                }
+            }
+        }
+
+        if (holder == null || narrowest == null)
+        {
+            return null;
+        }
+
+        return new AniDbAnimeListEpisode(
+            holder.AnimeId,
+            narrowest.InEntry.Start + (episodeNumber - narrowest.InSeason.Start),
+            narrowest.Kind);
+    }
+
+    /// <summary>
+    /// Which of the entries filed under one show the show begins in.
+    /// </summary>
+    /// <param name="siblings">Every entry the mappings file under the same show.</param>
+    /// <returns>The AniDB id of the earliest entry, or <c>null</c> where none of them fills a season.</returns>
+    public static string? PickFirstSeason(IReadOnlyList<AniBridgeEntry> siblings)
+    {
+        // The show begins in the entry filling its earliest season, and where that season was
+        // released in parts, in the part starting at its first episode. Where a season is
+        // filled by several entries starting together - a show and the recap or alternate
+        // version filed beside it - the oldest of them is the show itself, AniDB having
+        // registered it before whatever was made from it.
+        return siblings
+            .Select(entry => (Entry: entry, Claim: EarliestClaim(entry)))
+            .Where(candidate => candidate.Claim != null)
+            .OrderBy(candidate => candidate.Claim!.Season)
+            .ThenBy(candidate => candidate.Claim!.Start)
+            .ThenBy(candidate => NumericId(candidate.Entry.AnimeId))
+            .Select(candidate => candidate.Entry.AnimeId)
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// The season an entry fills, which is the earliest where it fills more than one.
+    /// </summary>
+    /// <param name="entry">The entry.</param>
+    /// <returns>The season number, or -1 where the entry fills no ordinary season.</returns>
+    public static int SeasonOf(AniBridgeEntry entry) => EarliestClaim(entry)?.Season ?? -1;
+
+    /// <summary>
+    /// How many episodes a span contributes, or zero where it runs to the end of the season.
+    /// </summary>
+    /// <param name="span">The span.</param>
+    /// <returns>The episode count.</returns>
+    private static int CountOf(AniBridgeSpan span)
+    {
+        // Where the two sides of a span disagree in length, the shorter is used: reading past
+        // the end of the entry would look for episodes it does not have, and reading past the
+        // end of the season would take episodes belonging to whatever comes next.
+        return (span.InSeason.Length, span.InEntry.Length) switch
+        {
+            ({ } inSeason, { } inEntry) => Math.Min(inSeason, inEntry),
+            ({ } inSeason, null) => inSeason,
+            (null, { } inEntry) => inEntry,
+            _ => 0,
+        };
+    }
+
+    /// <summary>
+    /// The earliest ordinary season an entry fills, and where in it the entry starts.
+    /// </summary>
+    /// <param name="entry">The entry.</param>
+    /// <returns>The claim, or <c>null</c> where the entry fills no ordinary season.</returns>
+    private static SeasonClaim? EarliestClaim(AniBridgeEntry entry)
+    {
+        SeasonClaim? earliest = null;
+
+        foreach (var span in entry.Spans)
+        {
+            if (span.Season < 1 || span.Kind == AniDbEpisodeKind.Special)
+            {
+                continue;
+            }
+
+            if (earliest == null
+                || span.Season < earliest.Season
+                || (span.Season == earliest.Season && span.InSeason.Start < earliest.Start))
+            {
+                earliest = new SeasonClaim(span.Season, span.InSeason.Start, entry.AnimeId);
+            }
+        }
+
+        return earliest;
+    }
+
+    /// <summary>
+    /// Which claim to keep where more than one names the same movie.
+    /// </summary>
+    /// <remarks>
+    /// An entry claims one movie twice wherever its ordinary numbering and its specials scope
+    /// both cover it - nineteen movies in the set at the time of writing - and the ordinary
+    /// episode is the better of the two: it is the entry AniDB registered for that movie, where
+    /// the special is the same movie listed again inside whatever it was released alongside.
+    /// </remarks>
+    /// <param name="claims">The claims read for one key.</param>
+    /// <returns>The claim to answer with.</returns>
+    private static AniDbAnimeListEpisode PickMovie(List<AniDbAnimeListEpisode> claims)
+        => claims
+            .OrderBy(claim => claim.Kind == AniDbEpisodeKind.Regular ? 0 : 1)
+            .ThenBy(claim => claim.Number)
+            .ThenBy(claim => NumericId(claim.AnimeId))
+            .First();
+
+    private static int NumericId(string animeId)
+        => int.TryParse(animeId, CultureInfo.InvariantCulture, out var parsed) ? parsed : int.MaxValue;
+
+    private static AniBridgeIndex Build(
+        Dictionary<string, List<AniBridgeSpan>> spans,
+        Dictionary<string, string> seriesKeys,
+        Dictionary<string, List<SeasonClaim>> tmdbCandidates,
+        Dictionary<string, List<AniDbAnimeListEpisode>> movies,
+        string? schemaVersion,
+        DateTime cachedAtUtc,
+        string description,
+        ILogger logger)
+    {
+        var byAnimeId = new Dictionary<string, AniBridgeEntry>(StringComparer.Ordinal);
+        var bySeries = new Dictionary<string, List<AniBridgeEntry>>(StringComparer.Ordinal);
+
+        foreach (var (animeId, seriesKey) in seriesKeys)
+        {
+            var entry = new AniBridgeEntry(animeId, seriesKey, spans.GetValueOrDefault(animeId) ?? []);
+
+            byAnimeId[animeId] = entry;
+
+            if (!bySeries.TryGetValue(seriesKey, out var siblings))
+            {
+                siblings = [];
+                bySeries[seriesKey] = siblings;
+            }
+
+            siblings.Add(entry);
+        }
+
+        var identifiedMovies = movies.ToDictionary(
+            pair => pair.Key,
+            pair => PickMovie(pair.Value),
+            StringComparer.Ordinal);
+
+        var firstSeasonByTmdb = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var (tmdbId, claims) in tmdbCandidates)
+        {
+            var first = claims
+                .OrderBy(claim => claim.Season)
+                .ThenBy(claim => claim.Start)
+                .ThenBy(claim => NumericId(claim.AnimeId))
+                .First();
+
+            firstSeasonByTmdb[tmdbId] = first.AnimeId;
+        }
+
+        logger.LogInformation(
+            "{Source}, last written on {WrittenAt} to schema {SchemaVersion}, place {EntryCount} AniDB entries across {SeriesCount} TVDB shows, identify {TmdbCount} TMDB shows and identify {MovieCount} movies",
+            description,
+            cachedAtUtc,
+            schemaVersion ?? "an unstated version",
+            byAnimeId.Count,
+            bySeries.Count,
+            firstSeasonByTmdb.Count,
+            identifiedMovies.Values.Distinct().Count());
+
+        return new AniBridgeIndex(
+            byAnimeId,
+            bySeries.ToDictionary(pair => pair.Key, pair => (IReadOnlyList<AniBridgeEntry>)pair.Value, StringComparer.Ordinal),
+            firstSeasonByTmdb,
+            identifiedMovies);
+    }
+
+    private static string? ReadSchemaVersion(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            return null;
+        }
+
+        string? version = null;
+
+        while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+        {
+            if (reader.ValueSpan.SequenceEqual("schema_version"u8))
+            {
+                reader.Read();
+
+                version = reader.TokenType == JsonTokenType.String ? reader.GetString() : null;
+            }
+            else
+            {
+                reader.Skip();
+            }
+        }
+
+        return version;
+    }
+
+    private static void ReadTargets(
+        ref Utf8JsonReader reader,
+        string animeId,
+        AniDbEpisodeKind kind,
+        Dictionary<string, List<AniBridgeSpan>> spans,
+        Dictionary<string, string> seriesKeys,
+        Dictionary<string, List<SeasonClaim>> tmdbCandidates,
+        Dictionary<string, List<AniDbAnimeListEpisode>> movies)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            return;
+        }
+
+        while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+        {
+            var isTvdb = reader.ValueSpan.StartsWith("tvdb_show:"u8);
+
+            // A movie is keyed by its own id with whichever provider, and by no season: the
+            // library holds it as one item, so there is nothing to lay over a numbering.
+            var isMovie = !isTvdb
+                && (reader.ValueSpan.StartsWith("tmdb_movie:"u8)
+                    || reader.ValueSpan.StartsWith("imdb_movie:"u8)
+                    || reader.ValueSpan.StartsWith("tvdb_movie:"u8));
+
+            // TMDB is read for identification only, not for placing seasons: the numbering a
+            // season is placed against has to be the one Jellyfin numbered the season by, and
+            // that is what the show's own provider settled on. Placing TVDB runs against TMDB
+            // seasons would move every episode of a show the two databases split differently.
+            if (!isTvdb && !isMovie && !reader.ValueSpan.StartsWith("tmdb_show:"u8))
+            {
+                reader.Skip();
+
+                continue;
+            }
+
+            var descriptor = reader.GetString()!;
+
+            reader.Read();
+
+            if (isMovie)
+            {
+                var key = MovieKey.FromDescriptor(descriptor);
+
+                if (key == null)
+                {
+                    reader.Skip();
+                }
+                else
+                {
+                    ReadMovieClaim(ref reader, animeId, kind, key, movies);
+                }
+
+                continue;
+            }
+
+            if (!TryReadShow(descriptor, out var showId, out var season))
+            {
+                reader.Skip();
+
+                continue;
+            }
+
+            if (isTvdb)
+            {
+                ReadRanges(ref reader, animeId, kind, showId, season, spans, seriesKeys);
+            }
+            else
+            {
+                ReadTmdbClaim(ref reader, animeId, kind, showId, season, tmdbCandidates);
+            }
+        }
+    }
+
+    private static void ReadRanges(
+        ref Utf8JsonReader reader,
+        string animeId,
+        AniDbEpisodeKind kind,
+        string showId,
+        int season,
+        Dictionary<string, List<AniBridgeSpan>> spans,
+        Dictionary<string, string> seriesKeys)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            return;
+        }
+
+        while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+        {
+            var inEntry = AniBridgeRange.ReadAll(reader.GetString());
+
+            reader.Read();
+
+            // A range the mappings unmap outright is written as null, and one they write in a
+            // form this does not read comes back null too.
+            var inSeason = reader.TokenType == JsonTokenType.String ? AniBridgeRange.ReadTarget(reader.GetString()) : null;
+
+            if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+            {
+                reader.Skip();
+            }
+
+            if (inEntry == null || inSeason == null)
+            {
+                continue;
+            }
+
+            // A mapping listing several ranges, or weighting one side against the other, is read
+            // as the runs it pairs up into, so that a season numbered around an episode AniDB
+            // does not list is held as the two runs it really is rather than refused for the
+            // comma between them.
+            foreach (var (entryRun, seasonRun) in AniBridgeRange.Pair(inEntry, inSeason.Value.Ranges, inSeason.Value.Ratio))
+            {
+                if (ReadBand(kind, entryRun) is not { } banded)
+                {
+                    continue;
+                }
+
+                // The show is keyed by the id its episodes are placed against, so an entry only
+                // counts as placed once a span of it has been read.
+                seriesKeys.TryAdd(animeId, showId);
+
+                if (!spans.TryGetValue(animeId, out var list))
+                {
+                    list = [];
+                    spans[animeId] = list;
+                }
+
+                var span = new AniBridgeSpan(season, banded.InEntry, seasonRun, banded.Kind);
+
+                // The specials and other scopes of one entry say the same thing twice once the
+                // band above is read for what it is.
+                if (!list.Contains(span))
+                {
+                    list.Add(span);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads which episode of an entry a movie is.
+    /// </summary>
+    /// <remarks>
+    /// A movie's side of the mapping is a single episode, so only the entry's side is read. Most
+    /// name the entry's first ordinary episode, which is to say the movie is that AniDB entry;
+    /// the rest name a later episode, a special or one of the other episodes, which is to say
+    /// AniDB holds the movie inside an entry registered for something else.
+    /// </remarks>
+    /// <param name="reader">The reader, positioned at the movie's ranges.</param>
+    /// <param name="animeId">The AniDB id of the entry.</param>
+    /// <param name="kind">Which of the entry's numberings the scope named.</param>
+    /// <param name="key">The movie's key, from <see cref="MovieKey"/>.</param>
+    /// <param name="movies">Every claim read so far, by key.</param>
+    private static void ReadMovieClaim(
+        ref Utf8JsonReader reader,
+        string animeId,
+        AniDbEpisodeKind kind,
+        string key,
+        Dictionary<string, List<AniDbAnimeListEpisode>> movies)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            return;
+        }
+
+        while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+        {
+            var inEntry = AniBridgeRange.Read(reader.GetString());
+
+            reader.Read();
+
+            if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+            {
+                reader.Skip();
+            }
+
+            // Only a range the movie is actually mapped onto counts. A null unmaps it outright.
+            if (inEntry == null || reader.TokenType == JsonTokenType.Null || ReadBand(kind, inEntry) is not { } banded)
+            {
+                continue;
+            }
+
+            var claim = new AniDbAnimeListEpisode(animeId, banded.InEntry.Start, banded.Kind);
+
+            if (!movies.TryGetValue(key, out var claims))
+            {
+                claims = [];
+                movies[key] = claims;
+            }
+
+            if (!claims.Contains(claim))
+            {
+                claims.Add(claim);
+            }
+        }
+    }
+
+    private static void ReadTmdbClaim(
+        ref Utf8JsonReader reader,
+        string animeId,
+        AniDbEpisodeKind kind,
+        string showId,
+        int season,
+        Dictionary<string, List<SeasonClaim>> tmdbCandidates)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            return;
+        }
+
+        var earliest = int.MaxValue;
+
+        while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+        {
+            reader.Read();
+
+            var inSeason = reader.TokenType == JsonTokenType.String ? AniBridgeRange.ReadTarget(reader.GetString()) : null;
+
+            if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+            {
+                reader.Skip();
+            }
+
+            // Only where the entry starts is wanted, so a run listing several ranges is worth
+            // no more than its first episode, and a ratio over them is worth nothing at all.
+            if (inSeason is { } side && side.Ranges[0].Start < earliest)
+            {
+                earliest = side.Ranges[0].Start;
+            }
+        }
+
+        if (kind != AniDbEpisodeKind.Regular || season < 1 || earliest == int.MaxValue)
+        {
+            return;
+        }
+
+        if (!tmdbCandidates.TryGetValue(showId, out var claims))
+        {
+            claims = [];
+            tmdbCandidates[showId] = claims;
+        }
+
+        claims.Add(new SeasonClaim(season, earliest, animeId));
+    }
+
+    /// <summary>
+    /// Reads a source descriptor, which is "anidb:&lt;id&gt;:&lt;scope&gt;".
+    /// </summary>
+    /// <param name="descriptor">The descriptor as written.</param>
+    /// <param name="animeId">The AniDB id.</param>
+    /// <param name="kind">Which of the entry's numberings the scope counts.</param>
+    /// <returns><c>true</c> where the descriptor names a scope this reads.</returns>
+    private static bool TryReadScope(string descriptor, out string animeId, out AniDbEpisodeKind kind)
+    {
+        animeId = string.Empty;
+        kind = AniDbEpisodeKind.Regular;
+
+        var parts = descriptor.Split(':');
+
+        if (parts.Length != 3 || parts[1].Length == 0 || !parts[1].All(char.IsAsciiDigit))
+        {
+            return false;
+        }
+
+        // "R" numbers the entry's ordinary episodes, "S" its specials and "O" its other
+        // episodes. Anything else is a scope this does not read.
+        switch (parts[2])
+        {
+            case "R":
+                break;
+            case "S":
+                kind = AniDbEpisodeKind.Special;
+                break;
+            case "O":
+                kind = AniDbEpisodeKind.Other;
+                break;
+            default:
+                return false;
+        }
+
+        animeId = parts[1];
+
+        return true;
+    }
+
+    /// <summary>
+    /// Rewrites a span of the specials scope that is really one of the other episodes.
+    /// </summary>
+    /// <remarks>
+    /// The specials scope numbers every episode that is not an ordinary one in a single run,
+    /// AniDB's type deciding where in it a number falls: specials from 1, and the other
+    /// episodes from 401. Every number in the set is in one band or the other, and where an
+    /// entry carries both scopes they say the same thing twice - anime 13473's specials scope
+    /// maps 401-412 onto the same season episodes its other scope maps 1-12 onto - so reading
+    /// the band as what it is makes the two agree instead of compete, and gives the six entries
+    /// that carry only the specials scope an answer that names a document on disk.
+    /// </remarks>
+    /// <param name="kind">The kind the scope named.</param>
+    /// <param name="inEntry">The episodes of the entry the span covers.</param>
+    /// <returns>The kind and range to record, or <c>null</c> where the range falls in neither band.</returns>
+    private static (AniDbEpisodeKind Kind, AniBridgeRange InEntry)? ReadBand(AniDbEpisodeKind kind, AniBridgeRange inEntry)
+    {
+        if (kind != AniDbEpisodeKind.Special || inEntry.Start < OtherEpisodeBand)
+        {
+            // A special numbered into a later band alongside one that is not cannot be read as
+            // either, and no such span exists in the set.
+            return inEntry.End >= OtherEpisodeBand && kind == AniDbEpisodeKind.Special
+                ? null
+                : (kind, inEntry);
+        }
+
+        return (
+            AniDbEpisodeKind.Other,
+            new AniBridgeRange(inEntry.Start - OtherEpisodeBand, inEntry.End is { } end ? end - OtherEpisodeBand : null));
+    }
+
+    /// <summary>
+    /// Reads a show descriptor, which is "&lt;provider&gt;:&lt;id&gt;:s&lt;season&gt;".
+    /// </summary>
+    /// <param name="descriptor">The descriptor as written.</param>
+    /// <param name="showId">The show's id with the provider.</param>
+    /// <param name="season">The season number, 0 being the specials.</param>
+    /// <returns><c>true</c> where the descriptor names a numbered season.</returns>
+    private static bool TryReadShow(string descriptor, out string showId, out int season)
+    {
+        showId = string.Empty;
+        season = -1;
+
+        var parts = descriptor.Split(':');
+
+        if (parts.Length != 3
+            || parts[1].Length == 0
+            || !parts[1].All(char.IsAsciiDigit)
+            || parts[2].Length < 2
+            || parts[2][0] != 's'
+            || !int.TryParse(parts[2].AsSpan(1), CultureInfo.InvariantCulture, out season))
+        {
+            return false;
+        }
+
+        showId = parts[1];
+
+        return true;
+    }
+
+    /// <summary>
+    /// One entry's claim on a season, used to work out which entry a show begins in.
+    /// </summary>
+    /// <param name="Season">The season claimed.</param>
+    /// <param name="Start">The episode of that season the entry starts at.</param>
+    /// <param name="AnimeId">The AniDB id of the entry.</param>
+    private sealed record SeasonClaim(int Season, int Start, string AnimeId);
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeMappings.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeMappings.cs
@@ -1,0 +1,361 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+using MediaBrowser.Common.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// The AniBridge mappings, which record which episodes of which AniDB entry fill which episodes
+/// of which season of a show. They state both sides of every placement outright, where the
+/// anime list leaves one to be worked out from an offset, and they carry TMDB show ids, which
+/// the anime list does not.
+/// </summary>
+internal static class AniBridgeMappings
+{
+    /// <summary>
+    /// The account and repository the mappings are released from.
+    /// </summary>
+    private const string Owner = "anibridge";
+    private const string Repository = "anibridge-mappings";
+
+    /// <summary>
+    /// The release the mappings are downloaded from. The tag names the schema the reader
+    /// understands, and it is a rolling release rebuilt daily, so it always carries the newest
+    /// build of that schema and a later schema never arrives unannounced. Raising this is how a
+    /// later one is taken up, alongside whatever the reader needs to read it.
+    /// </summary>
+    private const string ReleaseTag = "v3";
+
+    /// <summary>
+    /// The asset of that release which holds the mappings.
+    /// </summary>
+    private const string AssetName = "mappings.min.json";
+
+    /// <summary>
+    /// Where the asset is downloaded from where the release cannot be asked which build it is
+    /// holding. The tag resolves to whatever is attached to it, so this is the same file, only
+    /// fetched without knowing whether it is the one already cached.
+    /// </summary>
+    private const string MappingsUrl = "https://github.com/" + Owner + "/" + Repository + "/releases/download/" + ReleaseTag + "/" + AssetName;
+
+    /// <summary>
+    /// How long a downloaded copy is used before it is fetched again. The mappings are rebuilt
+    /// daily, but they gain shows rather than change the ones already placed, and a show already
+    /// in a library is placed the same way a week later.
+    /// </summary>
+    private const int MaxAgeDays = 7;
+
+    private const string Description = "the AniBridge mappings";
+
+    private static readonly MappingSourceCache<AniBridgeIndex> _cache = new(
+        "anibridge-mappings.json",
+        MappingsUrl,
+        Description,
+        MaxAgeDays,
+        (path, logger, cachedAtUtc) => AniBridgeIndex.Parse(path, logger, cachedAtUtc, Description),
+        resolve: (httpClient, cancellationToken) => GitHubRelease.ResolveAsset(
+            httpClient,
+            Owner,
+            Repository,
+            ReleaseTag,
+            AssetName,
+            cancellationToken));
+
+    /// <summary>
+    /// The AniDB entries the given season of the given series is filled from, in the order the
+    /// season's episodes run through them.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="seasonNumber">The season number.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The segments, or <c>null</c> when the mappings do not place that season.</returns>
+    public static async Task<IReadOnlyList<AniDbSeasonSegment>?> ResolveSeason(
+        IApplicationPaths appPaths,
+        string seriesId,
+        int seasonNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (seasonNumber < 1)
+        {
+            return null;
+        }
+
+        var index = await GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        if (index == null)
+        {
+            return null;
+        }
+
+        var key = FormattableString.Invariant($"{seriesId}/{seasonNumber}");
+
+        if (index.Placements.TryGetValue(key, out var known))
+        {
+            return known.Count == 0 ? null : known;
+        }
+
+        var siblings = index.Siblings(seriesId);
+        var segments = siblings == null ? [] : AniBridgeIndex.Place(siblings, seasonNumber);
+
+        // One line per season, and only at debug: the season resolver reports the placement it
+        // settles on, so reporting each source's own account again would say it twice. Every
+        // episode of the season asks the same question and gets the same answer, so the memo
+        // above is what keeps this from being logged per episode.
+        if (index.Placements.TryAdd(key, segments) && segments.Count > 0)
+        {
+            logger.LogDebug(
+                "The AniBridge mappings fill season {SeasonNumber} of AniDB series {SeriesId} with {Placement}",
+                seasonNumber,
+                seriesId,
+                string.Join(", ", segments.Select(SeasonSegments.Describe)));
+        }
+
+        return segments.Count == 0 ? null : segments;
+    }
+
+    /// <summary>
+    /// The AniDB entry a show begins in, found from the TVDB id another provider has already
+    /// settled on.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="tvdbId">The TVDB id of the series.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB id, or <c>null</c> when the mappings place nothing against that TVDB id.</returns>
+    public static async Task<string?> ResolveSeriesId(
+        IApplicationPaths appPaths,
+        string? tvdbId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(tvdbId) || !tvdbId.All(char.IsAsciiDigit))
+        {
+            return null;
+        }
+
+        var index = await GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.FirstSeasonByTvdb(tvdbId);
+    }
+
+    /// <summary>
+    /// The AniDB entry a show begins in, found from the TMDB id another provider has already
+    /// settled on. Jellyfin takes TMDB as the provider for shows by default, so for a great
+    /// many libraries this is the only id the show carries.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="tmdbId">The TMDB id of the series.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB id, or <c>null</c> when the mappings place nothing against that TMDB id.</returns>
+    public static async Task<string?> ResolveSeriesIdByTmdb(
+        IApplicationPaths appPaths,
+        string? tmdbId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(tmdbId) || !tmdbId.All(char.IsAsciiDigit))
+        {
+            return null;
+        }
+
+        var index = await GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.FirstSeasonByTmdb(tmdbId);
+    }
+
+    /// <summary>
+    /// The AniDB entry a movie is, and which of its episodes holds it.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="key">The movie's key, from <see cref="MovieKey"/>.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The episode, or <c>null</c> when the mappings identify no movie under that id.</returns>
+    public static async Task<AniDbAnimeListEpisode?> ResolveMovie(
+        IApplicationPaths appPaths,
+        string? key,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return null;
+        }
+
+        var index = await GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.ResolveMovie(key);
+    }
+
+    /// <summary>
+    /// The show an entry is filed under, as the TVDB id its seasons are numbered against.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The TVDB id, or <c>null</c> where the mappings do not place the entry.</returns>
+    public static async Task<string?> ResolveSeriesKey(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.SeriesKeyOf(animeId);
+    }
+
+    /// <summary>
+    /// The entry a show begins in, given an entry of it that the mappings file as a later
+    /// season.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id the name match produced.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB id the show begins at, or <c>null</c> where the mappings do not place the entry or already place it at the show's first season.</returns>
+    public static async Task<string?> ResolveFirstSeason(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(animeId))
+        {
+            return null;
+        }
+
+        var index = await GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.WalkBackToFirstSeason(animeId);
+    }
+
+    /// <summary>
+    /// Where the given episode of the specials season is read from.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="episodeNumber">The episode number within the specials season.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The episode, or <c>null</c> when the mappings do not place it.</returns>
+    public static async Task<AniDbAnimeListEpisode?> ResolveSpecial(
+        IApplicationPaths appPaths,
+        string seriesId,
+        int episodeNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+        var siblings = index?.Siblings(seriesId);
+
+        if (siblings == null)
+        {
+            return null;
+        }
+
+        var placed = AniBridgeIndex.PlaceSpecial(siblings, episodeNumber);
+
+        if (placed != null)
+        {
+            logger.LogDebug(
+                "The AniBridge mappings place special {EpisodeNumber} of AniDB series {SeriesId} in anime {AnimeId}",
+                episodeNumber,
+                seriesId,
+                placed.AnimeId);
+        }
+
+        return placed;
+    }
+
+    /// <summary>
+    /// Whether the mappings file the given entry in an ordinary season of a show.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of the entry.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><c>true</c> where the mappings place the entry in a season of its own.</returns>
+    public static async Task<bool> FilesInOrdinarySeason(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.FilesInOrdinarySeason(animeId) == true;
+    }
+
+    /// <summary>
+    /// Whether the mappings place the given show at all, which says whether an answer another
+    /// source gave is one these disagree with or one they simply do not have.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><c>true</c> where the mappings place the show.</returns>
+    public static async Task<bool> Places(
+        IApplicationPaths appPaths,
+        string seriesId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.Siblings(seriesId) != null;
+    }
+
+    /// <summary>
+    /// Asks the release what build it carries now, whatever the age of the cached copy, and
+    /// downloads it where it has been rebuilt since. For the button on the configuration page.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>What the check came to.</returns>
+    internal static Task<MappingSourceCheck> CheckNow(IApplicationPaths appPaths, ILogger logger, CancellationToken cancellationToken)
+        => Plugin.Instance.Configuration.UseAniBridgeMappings
+            ? _cache.CheckNow(appPaths, logger, cancellationToken)
+            : Task.FromResult(MappingSourceCheck.NotUsed);
+
+    /// <summary>
+    /// What is known of the mappings, for the status the configuration page shows.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <returns>When the cached copy was downloaded, when the release was last asked whether it holds a newer build, how many entries have been read from the copy, and how many days one is used for.</returns>
+    internal static (DateTime? CachedAtUtc, DateTime? CheckedAtUtc, int EntryCount, int MaxAgeInDays) GetStatus(IApplicationPaths appPaths)
+    {
+        var (cachedAtUtc, checkedAtUtc, index, maxAgeInDays, _) = _cache.GetStatus(appPaths);
+
+        return (cachedAtUtc, checkedAtUtc, index?.EntryCount ?? 0, maxAgeInDays);
+    }
+
+    /// <summary>
+    /// The mappings, or <c>null</c> where they are switched off or could not be read.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The mappings.</returns>
+    private static Task<AniBridgeIndex?> GetIndex(IApplicationPaths appPaths, ILogger logger, CancellationToken cancellationToken)
+    {
+        if (!Plugin.Instance.Configuration.UseAniBridgeMappings)
+        {
+            return Task.FromResult<AniBridgeIndex?>(null);
+        }
+
+        return _cache.GetIndex(appPaths, logger, cancellationToken);
+    }
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeRange.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeRange.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// A run of consecutive episode numbers, as the AniBridge mappings write one.
+/// </summary>
+/// <param name="Start">The first episode of the run.</param>
+/// <param name="End">The last episode, or <c>null</c> where the run has no end written and so goes on to the end of whatever holds it, as the season now airing does.</param>
+internal sealed record AniBridgeRange(int Start, int? End)
+{
+    /// <summary>
+    /// How far a run with no end written is walked out where a ratio has to be applied to it
+    /// episode by episode. Nothing a library numbers as one season runs anything like this long,
+    /// so a run cut here is cut past the end of whatever it could be filling.
+    /// </summary>
+    private const int MaxWalkedEpisodes = 2000;
+
+    /// <summary>
+    /// Gets how many episodes the run holds, or <c>null</c> where it has no end.
+    /// </summary>
+    public int? Length => End is { } end ? Math.Max(end - Start + 1, 0) : null;
+
+    /// <summary>
+    /// Reads a run as the mappings write one: "5" for a single episode, "42-63" for a range, or
+    /// "14-" for one that goes on.
+    /// </summary>
+    /// <param name="value">The run as written.</param>
+    /// <returns>The run, or <c>null</c> where it is not one of those three forms.</returns>
+    public static AniBridgeRange? Read(string? value)
+    {
+        // One range and nothing else. The entry's side of a mapping is written that way and
+        // that way only, and so is every part of the season's side once ReadAll has split it on
+        // its commas and ReadTarget has taken the ratio off its end.
+        if (string.IsNullOrEmpty(value) || value.AsSpan().IndexOfAny(',', '|') >= 0)
+        {
+            return null;
+        }
+
+        var span = value.AsSpan().Trim();
+        var separator = span.IndexOf('-');
+
+        if (separator < 0)
+        {
+            return int.TryParse(span, CultureInfo.InvariantCulture, out var only) ? new AniBridgeRange(only, only) : null;
+        }
+
+        if (!int.TryParse(span[..separator], CultureInfo.InvariantCulture, out var start))
+        {
+            return null;
+        }
+
+        var rest = span[(separator + 1)..];
+
+        if (rest.IsEmpty)
+        {
+            return new AniBridgeRange(start, null);
+        }
+
+        return int.TryParse(rest, CultureInfo.InvariantCulture, out var end) ? new AniBridgeRange(start, end) : null;
+    }
+
+    /// <summary>
+    /// Reads a run that may list several ranges, as "1-7,9,11-17" does. The schema lists them on
+    /// the season's side only, but a hand-written file is read the same way on either.
+    /// </summary>
+    /// <param name="value">The run as written, with any ratio already taken off it by <see cref="ReadTarget"/>.</param>
+    /// <returns>The ranges, in the order they are written, or <c>null</c> where any of them is not a form this reads.</returns>
+    public static IReadOnlyList<AniBridgeRange>? ReadAll(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return null;
+        }
+
+        if (!value.Contains(',', StringComparison.Ordinal))
+        {
+            return Read(value) is { } only ? [only] : null;
+        }
+
+        var ranges = new List<AniBridgeRange>();
+
+        foreach (var part in value.Split(','))
+        {
+            // Only the last range of a list may go on without an end: one in the middle has no
+            // length, so nothing written after it could be paired against the other side.
+            if (Read(part) is not { } range || (ranges.Count > 0 && ranges[^1].End == null))
+            {
+                return null;
+            }
+
+            ranges.Add(range);
+        }
+
+        return ranges.Count == 0 ? null : ranges;
+    }
+
+    /// <summary>
+    /// Reads the season's side of a mapping, which may list several ranges and may end with a
+    /// ratio weighting its episodes against the entry's, as "14-|2" does.
+    /// </summary>
+    /// <remarks>
+    /// The ratio is the season's side alone, and says which way round the weighting goes by its
+    /// sign, so there is nothing to read on the entry's side and no second direction to write:
+    /// "1-2" against "1|-2" is the same statement as "1" against "1-2|2" read backwards.
+    /// </remarks>
+    /// <param name="value">The side as written.</param>
+    /// <returns>The ranges and the ratio, or <c>null</c> where any part of it is not a form this reads. The ratio is 1 where none is written, <c>n</c> where each episode of the entry spans <c>n</c> of the season's, and <c>-n</c> where each episode of the season spans <c>n</c> of the entry's.</returns>
+    public static (IReadOnlyList<AniBridgeRange> Ranges, int Ratio)? ReadTarget(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return null;
+        }
+
+        var separator = value.IndexOf('|', StringComparison.Ordinal);
+
+        if (separator < 0)
+        {
+            return ReadAll(value) is { } plain ? (plain, 1) : null;
+        }
+
+        // Written once and last, so a second one anywhere leaves this to fail on the rest. A
+        // ratio of nothing per episode maps nothing and is not a mapping.
+        var ratio = value.AsSpan(separator + 1).Trim();
+
+        if (!int.TryParse(ratio, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var weight) || weight == 0)
+        {
+            return null;
+        }
+
+        return ReadAll(value[..separator]) is { } ranges ? (ranges, weight) : null;
+    }
+
+    /// <summary>
+    /// Pairs the two sides of a mapping episode by episode, cutting each side wherever the
+    /// other begins a new range.
+    /// </summary>
+    /// <param name="inEntry">The episodes of the entry, as written.</param>
+    /// <param name="inSeason">The episodes of the season they fill, as written.</param>
+    /// <param name="ratio">The ratio the season's side carries, from <see cref="ReadTarget"/>, or 1 where it carries none.</param>
+    /// <returns>The runs to record, each of the same length on both sides. Episodes past the end of the shorter side are left unpaired.</returns>
+    public static IEnumerable<(AniBridgeRange InEntry, AniBridgeRange InSeason)> Pair(
+        IReadOnlyList<AniBridgeRange> inEntry,
+        IReadOnlyList<AniBridgeRange> inSeason,
+        int ratio = 1)
+    {
+        ArgumentNullException.ThrowIfNull(inEntry);
+        ArgumentNullException.ThrowIfNull(inSeason);
+
+        // One episode of the entry to one of the season, whichever sign it is written with, is
+        // what a mapping carrying no ratio says as well.
+        return ratio is 1 or -1
+            ? PairEvenly(inEntry, inSeason)
+            : PairByRatio(inEntry, inSeason, ratio);
+    }
+
+    private static IEnumerable<(AniBridgeRange InEntry, AniBridgeRange InSeason)> PairEvenly(
+        IReadOnlyList<AniBridgeRange> inEntry,
+        IReadOnlyList<AniBridgeRange> inSeason)
+    {
+        // A mapping written as one range against another is passed through as it stands, open
+        // end and all, which is every mapping the downloaded sets write.
+        if (inEntry.Count == 1 && inSeason.Count == 1)
+        {
+            yield return (inEntry[0], inSeason[0]);
+
+            yield break;
+        }
+
+        var entryIndex = 0;
+        var seasonIndex = 0;
+        var takenFromEntry = 0;
+        var takenFromSeason = 0;
+
+        while (entryIndex < inEntry.Count && seasonIndex < inSeason.Count)
+        {
+            var entryRun = inEntry[entryIndex];
+            var seasonRun = inSeason[seasonIndex];
+            var leftInEntry = entryRun.Length - takenFromEntry;
+            var leftInSeason = seasonRun.Length - takenFromSeason;
+
+            // A range written backwards holds nothing, and is stepped over rather than read as
+            // the end of the list.
+            if (leftInEntry == 0)
+            {
+                entryIndex++;
+                takenFromEntry = 0;
+
+                continue;
+            }
+
+            if (leftInSeason == 0)
+            {
+                seasonIndex++;
+                takenFromSeason = 0;
+
+                continue;
+            }
+
+            var entryStart = entryRun.Start + takenFromEntry;
+            var seasonStart = seasonRun.Start + takenFromSeason;
+
+            // Two runs that both go on cannot be cut anywhere, so they are the last pair.
+            if (leftInEntry == null && leftInSeason == null)
+            {
+                yield return (new AniBridgeRange(entryStart, null), new AniBridgeRange(seasonStart, null));
+
+                yield break;
+            }
+
+            var take = Math.Min(leftInEntry ?? int.MaxValue, leftInSeason ?? int.MaxValue);
+
+            yield return (
+                new AniBridgeRange(entryStart, entryStart + take - 1),
+                new AniBridgeRange(seasonStart, seasonStart + take - 1));
+
+            takenFromEntry += take;
+            takenFromSeason += take;
+
+            if (leftInEntry == take)
+            {
+                entryIndex++;
+                takenFromEntry = 0;
+            }
+
+            if (leftInSeason == take)
+            {
+                seasonIndex++;
+                takenFromSeason = 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pairs the two sides where a ratio weights one against the other, an episode of the season
+    /// at a time, since a run of them no longer answers to a run of the entry's.
+    /// </summary>
+    /// <remarks>
+    /// A positive ratio has each episode of the entry spanning that many of the season's, which
+    /// is a season that numbers a two-part episode as two where AniDB lists it as one: each of
+    /// those season episodes is described by the one AniDB episode holding it. A negative ratio
+    /// has it the other way, that many of the entry's episodes to one of the season's, which is a
+    /// season holding them as a single episode: that episode is described by the first of them,
+    /// there being one record to take and nothing here that numbers a second.
+    /// </remarks>
+    /// <param name="inEntry">The episodes of the entry, as written.</param>
+    /// <param name="inSeason">The episodes of the season they fill, as written.</param>
+    /// <param name="ratio">The ratio, which is neither 1 nor -1.</param>
+    /// <returns>The runs to record, one episode each.</returns>
+    private static IEnumerable<(AniBridgeRange InEntry, AniBridgeRange InSeason)> PairByRatio(
+        IReadOnlyList<AniBridgeRange> inEntry,
+        IReadOnlyList<AniBridgeRange> inSeason,
+        int ratio)
+    {
+        var entryEpisodes = Walk(inEntry);
+        var seasonEpisodes = Walk(inSeason);
+
+        for (var index = 0; index < seasonEpisodes.Count; index++)
+        {
+            // Which episode of the entry describes this one of the season: every ratio episodes
+            // along where the entry's are the wider, ratio episodes along each time where the
+            // season's are.
+            var inEntryIndex = ratio > 0 ? index / ratio : index * -ratio;
+
+            if (inEntryIndex >= entryEpisodes.Count)
+            {
+                yield break;
+            }
+
+            yield return (
+                new AniBridgeRange(entryEpisodes[inEntryIndex], entryEpisodes[inEntryIndex]),
+                new AniBridgeRange(seasonEpisodes[index], seasonEpisodes[index]));
+        }
+    }
+
+    /// <summary>
+    /// The episode numbers a side covers, in the order it lists them.
+    /// </summary>
+    /// <param name="ranges">The ranges of the side.</param>
+    /// <returns>The numbers, a run with no end written walked out to <see cref="MaxWalkedEpisodes"/>.</returns>
+    private static List<int> Walk(IReadOnlyList<AniBridgeRange> ranges)
+    {
+        var episodes = new List<int>();
+
+        foreach (var range in ranges)
+        {
+            // A range written backwards holds nothing and contributes nothing.
+            var last = range.End ?? int.MaxValue;
+
+            for (var episode = range.Start; episode <= last && episodes.Count < MaxWalkedEpisodes; episode++)
+            {
+                episodes.Add(episode);
+            }
+        }
+
+        return episodes;
+    }
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeSpan.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeSpan.cs
@@ -1,0 +1,14 @@
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// One run of an AniDB entry's episodes, and the run of a season's episodes they fill. The
+/// AniBridge mappings state both outright, where the anime list leaves the second to be worked
+/// out from an offset.
+/// </summary>
+/// <param name="Season">The season the run fills, or 0 for the specials.</param>
+/// <param name="InEntry">The episodes of the entry the run covers.</param>
+/// <param name="InSeason">The episodes of the season they fill.</param>
+/// <param name="Kind">Which of the entry's episode numberings <paramref name="InEntry"/> counts.</param>
+internal sealed record AniBridgeSpan(int Season, AniBridgeRange InEntry, AniBridgeRange InSeason, AniDbEpisodeKind Kind);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeList.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeList.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+using MediaBrowser.Common.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// The community anime list, which records which AniDB entry fills which season of a show.
+/// </summary>
+internal static class AniDbAnimeList
+{
+    /// <summary>
+    /// Where the list is downloaded from. It is a file in a branch rather than a release - the
+    /// repository publishes none - so there is nothing to ask which build is current, and the
+    /// server is asked instead: the entity tag of the last download is offered back, and the
+    /// list is sent again only where it has changed since.
+    /// </summary>
+    private const string ListUrl = "https://raw.githubusercontent.com/Anime-Lists/anime-lists/master/anime-list-full.xml";
+
+    /// <summary>
+    /// How long a downloaded list is used before it is fetched again. The list gains entries as
+    /// shows are announced, and an entry for a show already in a library rarely changes.
+    /// </summary>
+    private const int MaxAgeDays = 7;
+
+    private static readonly MappingSourceCache<AniDbAnimeListIndex> _cache = new(
+        "anime-list.xml",
+        ListUrl,
+        "the anime list",
+        MaxAgeDays,
+        AniDbAnimeListIndex.Parse);
+
+    /// <summary>
+    /// The AniDB entries the given season of the given series is filled from, in the order the
+    /// season's episodes run through them.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="seasonNumber">The season number.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The segments, or <c>null</c> when the list does not place that season.</returns>
+    public static async Task<IReadOnlyList<AniDbSeasonSegment>?> ResolveSeason(
+        IApplicationPaths appPaths,
+        string seriesId,
+        int seasonNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (seasonNumber < 1)
+        {
+            return null;
+        }
+
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        if (index == null)
+        {
+            return null;
+        }
+
+        var key = FormattableString.Invariant($"{seriesId}/{seasonNumber}");
+
+        if (index.Placements.TryGetValue(key, out var known))
+        {
+            return known.Count == 0 ? null : known;
+        }
+
+        var siblings = index.Siblings(seriesId);
+        var segments = siblings == null ? [] : AniDbAnimeListIndex.Place(siblings, seasonNumber);
+
+        // One line per season, and only at debug: the season resolver reports the placement it
+        // settles on, so reporting each source's own account again would say it twice. Every
+        // episode of the season asks the same question and gets the same answer, so the memo
+        // above is what keeps this from being logged per episode.
+        if (index.Placements.TryAdd(key, segments) && segments.Count > 0)
+        {
+            logger.LogDebug(
+                "The anime list fills season {SeasonNumber} of AniDB series {SeriesId} with {Placement}",
+                seasonNumber,
+                seriesId,
+                string.Join(", ", segments.Select(SeasonSegments.Describe)));
+        }
+
+        return segments.Count == 0 ? null : segments;
+    }
+
+    /// <summary>
+    /// The AniDB entry a show begins in, found from the TVDB id another provider has already
+    /// settled on. The list keys its entries by TVDB id, so this identifies a show outright
+    /// where matching on the name cannot: where AniDB spells the name differently, and where
+    /// two shows share one name and only the id tells them apart.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="tvdbId">The TVDB id of the series.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB id, or <c>null</c> when the list files nothing under that TVDB id.</returns>
+    public static async Task<string?> ResolveSeriesId(
+        IApplicationPaths appPaths,
+        string? tvdbId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        // Anything else is a placeholder the list uses for a show TVDB does not carry, and
+        // those are not keys of the index below.
+        if (string.IsNullOrEmpty(tvdbId) || !tvdbId.All(char.IsAsciiDigit))
+        {
+            return null;
+        }
+
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.FirstSeasonByTvdb(tvdbId);
+    }
+
+    /// <summary>
+    /// The AniDB entry a movie is. The list carries a movie's ids on the entry itself, so what it
+    /// answers is always that entry's own first episode.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="key">The movie's key, from <see cref="MovieKey"/>.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The episode, or <c>null</c> when the list identifies no movie under that id.</returns>
+    public static async Task<AniDbAnimeListEpisode?> ResolveMovie(
+        IApplicationPaths appPaths,
+        string? key,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return null;
+        }
+
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.ResolveMovie(key);
+    }
+
+    /// <summary>
+    /// The show an entry is filed under, as the TVDB id its seasons are numbered against.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The TVDB id, or <c>null</c> where the list does not place the entry against one.</returns>
+    public static async Task<string?> ResolveSeriesKey(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+        var seriesKey = index?.SeriesKeyOf(animeId);
+
+        // The list keys a show TVDB does not carry under a placeholder word instead of an id.
+        return seriesKey != null && seriesKey.All(char.IsAsciiDigit) ? seriesKey : null;
+    }
+
+    /// <summary>
+    /// The entry a show begins in, given an entry of it that the list files as a later season.
+    /// AniDB titles a second season "&lt;name&gt; (&lt;year&gt;)" as readily as it titles a
+    /// remake that way, so a name match on a show whose seasons all aired in one year lands on
+    /// the sequel rather than on the show. The list records which season each entry fills, so
+    /// it can walk that back without asking AniDB anything.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id the name match produced.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB id the show begins at, or <c>null</c> where the list does not place the entry or already places it at the show's first season.</returns>
+    public static async Task<string?> ResolveFirstSeason(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(animeId))
+        {
+            return null;
+        }
+
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.WalkBackToFirstSeason(animeId);
+    }
+
+    /// <summary>
+    /// Where the given episode of the specials season is read from.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="episodeNumber">The episode number within the specials season.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The episode, or <c>null</c> when the list does not place it.</returns>
+    public static async Task<AniDbAnimeListEpisode?> ResolveSpecial(
+        IApplicationPaths appPaths,
+        string seriesId,
+        int episodeNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+        var siblings = index?.Siblings(seriesId);
+
+        if (siblings == null)
+        {
+            return null;
+        }
+
+        var placed = AniDbAnimeListIndex.PlaceSpecial(siblings, episodeNumber);
+
+        if (placed != null)
+        {
+            logger.LogDebug(
+                "The anime list places special {EpisodeNumber} of AniDB series {SeriesId} in anime {AnimeId}",
+                episodeNumber,
+                seriesId,
+                placed.AnimeId);
+        }
+
+        return placed;
+    }
+
+    /// <summary>
+    /// Asks the list what it holds now, whatever the age of the cached copy, and downloads it
+    /// where it has changed since. For the button on the configuration page.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>What the check came to.</returns>
+    internal static Task<MappingSourceCheck> CheckNow(IApplicationPaths appPaths, ILogger logger, CancellationToken cancellationToken)
+        => _cache.CheckNow(appPaths, logger, cancellationToken);
+
+    /// <summary>
+    /// What is known of the list, for the status the configuration page shows. Reads nothing
+    /// but the timestamp of the cached file, so it costs little to ask often.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <returns>When the cached copy was downloaded, when the source was last asked whether it holds a newer one, how many entries have been read from the copy, and how many days one is used for.</returns>
+    internal static (DateTime? CachedAtUtc, DateTime? CheckedAtUtc, int EntryCount, int MaxAgeInDays) GetStatus(IApplicationPaths appPaths)
+    {
+        var (cachedAtUtc, checkedAtUtc, index, maxAgeInDays, _) = _cache.GetStatus(appPaths);
+
+        return (cachedAtUtc, checkedAtUtc, index?.EntryCount ?? 0, maxAgeInDays);
+    }
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeListEntry.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeListEntry.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// One AniDB anime as the anime list places it: which series it belongs to, which season of that
+/// series it fills, and where in that season its episodes start.
+/// </summary>
+/// <param name="AnimeId">The AniDB id of the entry.</param>
+/// <param name="SeriesKey">The id of the series the entry belongs to, which is a TVDB series id where the entry has one.</param>
+/// <param name="DefaultSeason">The season the entry fills, as written: a number, "0" for the specials, or "a" for an entry numbered straight through the whole show.</param>
+/// <param name="EpisodeOffset">Added to the entry's episode number to give the season's.</param>
+/// <param name="Mappings">Rules correcting the placement above, episode range by episode range.</param>
+internal sealed record AniDbAnimeListEntry(
+    string AnimeId,
+    string SeriesKey,
+    string? DefaultSeason,
+    int EpisodeOffset,
+    IReadOnlyList<AniDbAnimeListMapping> Mappings);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeListEpisode.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeListEpisode.cs
@@ -1,0 +1,11 @@
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// Where a single episode is read from, once a mapping source has placed it.
+/// </summary>
+/// <param name="AnimeId">The AniDB id of the entry holding it.</param>
+/// <param name="Number">Its number within that entry.</param>
+/// <param name="Kind">Which of the entry's episode numberings that number belongs to.</param>
+internal sealed record AniDbAnimeListEpisode(string AnimeId, int Number, AniDbEpisodeKind Kind);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeListIndex.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeListIndex.cs
@@ -1,0 +1,497 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// The community anime list, as read from one downloaded copy of it.
+/// </summary>
+internal sealed class AniDbAnimeListIndex
+{
+    /// <summary>
+    /// Where AniDB's other episodes begin in the numbering the list writes the specials in.
+    /// </summary>
+    private const int OtherEpisodeBand = 400;
+
+    private readonly IReadOnlyDictionary<string, AniDbAnimeListEntry> _byAnimeId;
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<AniDbAnimeListEntry>> _bySeries;
+    private readonly IReadOnlyDictionary<string, AniDbAnimeListEpisode> _movies;
+
+    private AniDbAnimeListIndex(
+        IReadOnlyDictionary<string, AniDbAnimeListEntry> byAnimeId,
+        IReadOnlyDictionary<string, IReadOnlyList<AniDbAnimeListEntry>> bySeries,
+        IReadOnlyDictionary<string, AniDbAnimeListEpisode> movies)
+    {
+        _byAnimeId = byAnimeId;
+        _bySeries = bySeries;
+        _movies = movies;
+    }
+
+    /// <summary>
+    /// Gets the placement worked out for every season already asked about, keyed by series id
+    /// and season number, holding an empty list for a season the list does not place. Each of a
+    /// season's episodes asks the same question, and the answer changes only when the list is
+    /// read again, which replaces this along with it.
+    /// </summary>
+    public ConcurrentDictionary<string, IReadOnlyList<AniDbSeasonSegment>> Placements { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets how many AniDB entries the list places against a TVDB series.
+    /// </summary>
+    public int EntryCount => _byAnimeId.Count;
+
+    /// <summary>
+    /// Reads a downloaded copy of the list.
+    /// </summary>
+    /// <param name="path">Where the copy is cached.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cachedAtUtc">When the copy was written.</param>
+    /// <returns>The list.</returns>
+    public static AniDbAnimeListIndex Parse(string path, ILogger logger, DateTime cachedAtUtc)
+    {
+        var byAnimeId = new Dictionary<string, AniDbAnimeListEntry>(StringComparer.Ordinal);
+        var bySeries = new Dictionary<string, List<AniDbAnimeListEntry>>(StringComparer.Ordinal);
+        var movies = new Dictionary<string, AniDbAnimeListEpisode>(StringComparer.Ordinal);
+
+        foreach (var element in XDocument.Load(path).Root?.Elements("anime") ?? [])
+        {
+            var animeId = element.Attribute("anidbid")?.Value;
+            var seriesKey = element.Attribute("tvdbid")?.Value;
+
+            if (string.IsNullOrEmpty(animeId))
+            {
+                continue;
+            }
+
+            // Read before the series below, because the entries carrying a movie id are largely
+            // the ones with no series to be placed against: 893 of them are filed under the
+            // word "movie" where a TVDB id would go.
+            ReadMovieIds(element, animeId, movies);
+
+            // A movie or an OVA the list files under no series has nothing to place it against.
+            if (string.IsNullOrEmpty(seriesKey) || !seriesKey.All(char.IsAsciiDigit))
+            {
+                continue;
+            }
+
+            var entry = new AniDbAnimeListEntry(
+                animeId,
+                seriesKey,
+                element.Attribute("defaulttvdbseason")?.Value,
+                ReadInt(element.Attribute("episodeoffset")?.Value),
+                [.. element.Descendants("mapping").Select(ReadMapping).OfType<AniDbAnimeListMapping>()]);
+
+            byAnimeId[animeId] = entry;
+
+            if (!bySeries.TryGetValue(seriesKey, out var siblings))
+            {
+                siblings = [];
+                bySeries[seriesKey] = siblings;
+            }
+
+            siblings.Add(entry);
+        }
+
+        logger.LogInformation(
+            "The anime list cached on {CachedAt} places {EntryCount} AniDB entries across {SeriesCount} shows and identifies {MovieCount} movies",
+            cachedAtUtc,
+            byAnimeId.Count,
+            bySeries.Count,
+            movies.Values.Distinct().Count());
+
+        return new AniDbAnimeListIndex(
+            byAnimeId,
+            bySeries.ToDictionary(pair => pair.Key, pair => (IReadOnlyList<AniDbAnimeListEntry>)pair.Value, StringComparer.Ordinal),
+            movies);
+    }
+
+    /// <summary>
+    /// Every entry the list files under the same show as the given one.
+    /// </summary>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <returns>The entries, or <c>null</c> where the list does not place that one.</returns>
+    public IReadOnlyList<AniDbAnimeListEntry>? Siblings(string animeId)
+    {
+        if (!_byAnimeId.TryGetValue(animeId, out var self))
+        {
+            return null;
+        }
+
+        return _bySeries.TryGetValue(self.SeriesKey, out var siblings) ? siblings : null;
+    }
+
+    /// <summary>
+    /// The AniDB entry a movie is. The list carries a movie's ids on the entry itself, so what it
+    /// answers is always that entry's own first episode.
+    /// </summary>
+    /// <param name="key">The movie's key, from <see cref="MovieKey"/>.</param>
+    /// <returns>The episode, or <c>null</c> where the list identifies no movie under that id.</returns>
+    public AniDbAnimeListEpisode? ResolveMovie(string key)
+        => _movies.GetValueOrDefault(key);
+
+    /// <summary>
+    /// The show an entry is filed under, as the id its seasons are numbered against. What a
+    /// sparsely written set of mappings is reached through, which names one entry of a show
+    /// rather than the entry the show is identified as.
+    /// </summary>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <returns>The series key, or <c>null</c> where the list does not place that entry.</returns>
+    public string? SeriesKeyOf(string animeId)
+        => _byAnimeId.TryGetValue(animeId, out var entry) ? entry.SeriesKey : null;
+
+    /// <summary>
+    /// The entry a show begins in, found from the TVDB id another provider has already settled
+    /// on. The list keys its entries by TVDB id, so this identifies a show outright where
+    /// matching on the name cannot: where AniDB spells the name differently, and where two
+    /// shows share one name and only the id tells them apart.
+    /// </summary>
+    /// <param name="tvdbId">The TVDB series id.</param>
+    /// <returns>The AniDB id, or <c>null</c> where the list files nothing under that id.</returns>
+    public string? FirstSeasonByTvdb(string tvdbId)
+        => _bySeries.TryGetValue(tvdbId, out var siblings) ? PickFirstSeason(siblings) : null;
+
+    /// <summary>
+    /// The entry a show begins in, given an entry of it the list files as a later season.
+    /// </summary>
+    /// <param name="animeId">The AniDB id the name match produced.</param>
+    /// <returns>The AniDB id the show begins at, or <c>null</c> where the list does not place the entry or already places it at the show's first season.</returns>
+    public string? WalkBackToFirstSeason(string animeId)
+    {
+        // Only an entry the list files as a second season or later is walked back. An entry it
+        // already files at season 1 is the show's own start, and moving it could only hand the
+        // show to whatever else shares its TVDB id: the list groups a handful of unrelated
+        // shows under one id, and two adaptations of one book sit that way under season 1.
+        if (!_byAnimeId.TryGetValue(animeId, out var self) || SeasonOf(self) <= 1)
+        {
+            return null;
+        }
+
+        if (!_bySeries.TryGetValue(self.SeriesKey, out var siblings))
+        {
+            return null;
+        }
+
+        var first = PickFirstSeason(siblings);
+
+        return string.Equals(first, animeId, StringComparison.Ordinal) ? null : first;
+    }
+
+    /// <summary>
+    /// Which of the entries filed under one show the show begins in.
+    /// </summary>
+    /// <param name="siblings">Every entry the list files under the same show.</param>
+    /// <returns>The AniDB id of the earliest entry, or <c>null</c> when none of them fills a season.</returns>
+    public static string? PickFirstSeason(IReadOnlyList<AniDbAnimeListEntry> siblings)
+    {
+        // The show begins in the entry filling its earliest season, and where that season was
+        // released in parts, in the part starting at its first episode. Where a season is
+        // filled by several entries starting together - a show and the recap or alternate
+        // version filed beside it - the oldest of them is the show itself, AniDB having
+        // registered it before whatever was made from it.
+        //
+        // Season 0 is an entry holding nothing but specials, which is never where a show
+        // begins, and a season that will not parse is one the list cannot place at all.
+        return siblings
+            .Select(entry => (Entry: entry, Season: SeasonOf(entry)))
+            .Where(candidate => candidate.Season >= 1)
+            .OrderBy(candidate => candidate.Season)
+            .ThenBy(candidate => candidate.Entry.EpisodeOffset)
+            .ThenBy(candidate => int.TryParse(candidate.Entry.AnimeId, CultureInfo.InvariantCulture, out var id) ? id : int.MaxValue)
+            .Select(candidate => candidate.Entry.AnimeId)
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// The season an entry fills, as a number. An entry numbered straight through the whole
+    /// show carries "a" rather than a season, and covers that show from its first episode.
+    /// </summary>
+    /// <param name="entry">The entry.</param>
+    /// <returns>The season number, or -1 where the entry names no season this can read.</returns>
+    public static int SeasonOf(AniDbAnimeListEntry entry)
+    {
+        if (string.Equals(entry.DefaultSeason, "a", StringComparison.OrdinalIgnoreCase))
+        {
+            return 1;
+        }
+
+        return int.TryParse(entry.DefaultSeason, CultureInfo.InvariantCulture, out var parsed) ? parsed : -1;
+    }
+
+    /// <summary>
+    /// Works out which of a series' AniDB entries fill the given season, and which of their
+    /// episodes each one contributes.
+    /// </summary>
+    /// <param name="siblings">Every entry the list files under the same series.</param>
+    /// <param name="seasonNumber">The season number.</param>
+    /// <returns>The segments, in the order the season's episodes run through them.</returns>
+    public static IReadOnlyList<AniDbSeasonSegment> Place(IReadOnlyList<AniDbAnimeListEntry> siblings, int seasonNumber)
+    {
+        var claims = new Dictionary<AniDbEpisodeKind, List<AniDbSeasonSegment>>();
+
+        foreach (var entry in siblings)
+        {
+            // Which of the season's episodes this entry's rules account for. What is left over
+            // is what the season the entry names is for.
+            var named = new HashSet<int>();
+
+            foreach (var mapping in entry.Mappings)
+            {
+                if (mapping.TvdbSeason != seasonNumber)
+                {
+                    continue;
+                }
+
+                // A rule may name the season's episodes one by one rather than as a run, which
+                // is how a season whose episodes do not correspond one to one with the entry's
+                // is written. Each named episode is a segment of its own, one episode long.
+                foreach (var pair in mapping.Pairs)
+                {
+                    // A season number of 0 says the episode has no counterpart there.
+                    if (pair.Value <= 0)
+                    {
+                        continue;
+                    }
+
+                    var (kind, number) = Source(mapping, pair.Key);
+
+                    SeasonSegments.Add(claims, new AniDbSeasonSegment(entry.AnimeId, pair.Value, 1, number, kind));
+                    named.Add(pair.Value);
+                }
+
+                if (mapping.Start is not { } start || mapping.End < start)
+                {
+                    continue;
+                }
+
+                // A rule with no end runs to the end of the entry. That is how the list places
+                // the season now airing, whose last episode nobody knows yet, and dropping such
+                // a rule left that season with no placement at all.
+                var count = mapping.End is { } end ? end - start + 1 : 0;
+                var first = start + mapping.Offset;
+                var source = Source(mapping, start);
+
+                SeasonSegments.Add(claims, new AniDbSeasonSegment(entry.AnimeId, first, count, source.Number, source.Kind));
+
+                named.Add(first);
+
+                for (var offset = 1; offset < count; offset++)
+                {
+                    named.Add(first + offset);
+                }
+            }
+
+            if (!int.TryParse(entry.DefaultSeason, CultureInfo.InvariantCulture, out var defaultSeason)
+                || defaultSeason != seasonNumber)
+            {
+                continue;
+            }
+
+            var startsAt = entry.EpisodeOffset + 1;
+
+            // A rule already names the episode the rest of the entry would begin at, so the
+            // rules are the whole of what this entry gives the season.
+            if (named.Contains(startsAt))
+            {
+                continue;
+            }
+
+            // The list does not say how long an entry is, so the claim runs to the end of the
+            // season. It stops early where a rule hands the rest of the entry to another season,
+            // as a series split across two of them does, and where a rule names a later episode
+            // of this season: K-On!'s first season is the entry's twelve episodes and then two
+            // of its specials, so the twelve stop where the specials begin.
+            var handedOver = entry.Mappings
+                .Where(mapping => mapping.TvdbSeason != seasonNumber && mapping.AnidbSeason != 0 && mapping.Start.HasValue)
+                .Select(mapping => mapping.Start!.Value)
+                .DefaultIfEmpty(0)
+                .Min();
+
+            var nextNamed = named.Where(episode => episode > startsAt).DefaultIfEmpty(0).Min();
+
+            SeasonSegments.Add(
+                claims,
+                new AniDbSeasonSegment(
+                    entry.AnimeId,
+                    startsAt,
+                    nextNamed > 0 ? nextNamed - startsAt : Math.Max(handedOver - 1, 0),
+                    1));
+        }
+
+        return SeasonSegments.Resolve(claims);
+    }
+
+    /// <summary>
+    /// Where the given episode of the specials season is read from.
+    /// </summary>
+    /// <param name="siblings">Every entry the list files under the same series.</param>
+    /// <param name="episodeNumber">The episode number within the specials season.</param>
+    /// <returns>The episode, or <c>null</c> when the list does not place it.</returns>
+    public static AniDbAnimeListEpisode? PlaceSpecial(IReadOnlyList<AniDbAnimeListEntry> siblings, int episodeNumber)
+    {
+        // A rule naming this episode outright beats anything worked out from an offset.
+        foreach (var entry in siblings)
+        {
+            foreach (var mapping in entry.Mappings)
+            {
+                if (mapping.TvdbSeason != 0)
+                {
+                    continue;
+                }
+
+                foreach (var pair in mapping.Pairs)
+                {
+                    // A season number of 0 says the episode has no counterpart to name.
+                    if (pair.Value == episodeNumber && pair.Value != 0)
+                    {
+                        var (pairKind, pairNumber) = Source(mapping, pair.Key);
+
+                        return new AniDbAnimeListEpisode(entry.AnimeId, pairNumber, pairKind);
+                    }
+                }
+
+                if (mapping.Start is { } start)
+                {
+                    var number = episodeNumber - mapping.Offset;
+
+                    if (number >= start && number <= (mapping.End ?? int.MaxValue))
+                    {
+                        var source = Source(mapping, number);
+
+                        return new AniDbAnimeListEpisode(entry.AnimeId, source.Number, source.Kind);
+                    }
+                }
+            }
+        }
+
+        // Otherwise the entry that starts closest below this episode is the one holding it. An
+        // entry that has a rule for the specials has already had its say above.
+        AniDbAnimeListEntry? holder = null;
+
+        foreach (var entry in siblings)
+        {
+            if (!string.Equals(entry.DefaultSeason, "0", StringComparison.Ordinal)
+                || entry.EpisodeOffset >= episodeNumber
+                || entry.Mappings.Any(mapping => mapping.TvdbSeason == 0))
+            {
+                continue;
+            }
+
+            if (holder == null || entry.EpisodeOffset > holder.EpisodeOffset)
+            {
+                holder = entry;
+            }
+        }
+
+        return holder == null ? null : new AniDbAnimeListEpisode(holder.AnimeId, episodeNumber - holder.EpisodeOffset, AniDbEpisodeKind.Regular);
+    }
+
+    /// <summary>
+    /// Which of an entry's numberings a rule reads a given episode from, and that episode's
+    /// number within it.
+    /// </summary>
+    /// <remarks>
+    /// The list writes the numbering as a season of its own: 0 for everything that is not an
+    /// ordinary episode, within which the specials are numbered from 1 and AniDB's other
+    /// episodes from 401. The band therefore belongs to each number a rule names rather than to
+    /// the rule, one rule of Owarimonogatari (2017) naming 402 through 409.
+    /// </remarks>
+    /// <param name="mapping">The rule.</param>
+    /// <param name="number">The number the rule names on the entry's side.</param>
+    /// <returns>The numbering and the number within it.</returns>
+    private static (AniDbEpisodeKind Kind, int Number) Source(AniDbAnimeListMapping mapping, int number)
+    {
+        if (mapping.AnidbSeason != 0)
+        {
+            return (AniDbEpisodeKind.Regular, number);
+        }
+
+        return number >= OtherEpisodeBand
+            ? (AniDbEpisodeKind.Other, number - OtherEpisodeBand)
+            : (AniDbEpisodeKind.Special, number);
+    }
+
+    /// <summary>
+    /// Files an entry under whatever movie ids it carries.
+    /// </summary>
+    /// <remarks>
+    /// The list carries IMDb and TMDB ids for the 1,634 entries that are movies, an entry's
+    /// IMDb attribute holding several ids where one AniDB entry covers a movie released in
+    /// parts. The first entry to claim an id keeps it: the list is written in AniDB order, so
+    /// that is the earliest entry, and where two claim one movie the later is a remake or a
+    /// recut listed against the same release.
+    /// </remarks>
+    /// <param name="element">The anime element.</param>
+    /// <param name="animeId">The AniDB id of the entry.</param>
+    /// <param name="movies">Every movie identified so far, by key.</param>
+    private static void ReadMovieIds(XElement element, string animeId, Dictionary<string, AniDbAnimeListEpisode> movies)
+    {
+        var episode = new AniDbAnimeListEpisode(animeId, 1, AniDbEpisodeKind.Regular);
+
+        foreach (var written in (element.Attribute("imdbid")?.Value ?? string.Empty).Split(','))
+        {
+            if (MovieKey.Imdb(written) is { } key)
+            {
+                movies.TryAdd(key, episode);
+            }
+        }
+
+        if (MovieKey.Tmdb(element.Attribute("tmdbid")?.Value) is { } tmdbKey)
+        {
+            movies.TryAdd(tmdbKey, episode);
+        }
+    }
+
+    private static AniDbAnimeListMapping? ReadMapping(XElement element)
+    {
+        if (element.Attribute("tvdbseason") == null)
+        {
+            return null;
+        }
+
+        var pairs = new List<KeyValuePair<int, int>>();
+
+        foreach (var pair in (element.Value ?? string.Empty).Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var separator = pair.IndexOf('-', StringComparison.Ordinal);
+
+            if (separator <= 0 || !int.TryParse(pair[..separator], CultureInfo.InvariantCulture, out var inEntry))
+            {
+                continue;
+            }
+
+            // One episode of the entry can fill several of the season's, written "1-1+2+3".
+            // That is a movie the season numbering breaks into three episodes, as every season
+            // of Ginga Eiyuu Densetsu: Die Neue These past the first is. Reading only up to the
+            // plus left the whole rule unparsed, and the season was then placed as though the
+            // two sides ran one to one, which sent every episode past the first movie's to an
+            // episode of the entry that does not exist.
+            foreach (var inSeason in pair[(separator + 1)..].Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (int.TryParse(inSeason, CultureInfo.InvariantCulture, out var number))
+                {
+                    pairs.Add(new KeyValuePair<int, int>(inEntry, number));
+                }
+            }
+        }
+
+        return new AniDbAnimeListMapping(
+            ReadInt(element.Attribute("anidbseason")?.Value),
+            ReadInt(element.Attribute("tvdbseason")?.Value),
+            ReadNullableInt(element.Attribute("start")?.Value),
+            ReadNullableInt(element.Attribute("end")?.Value),
+            ReadInt(element.Attribute("offset")?.Value),
+            pairs);
+    }
+
+    private static int ReadInt(string? value)
+        => int.TryParse(value, CultureInfo.InvariantCulture, out var parsed) ? parsed : 0;
+
+    private static int? ReadNullableInt(string? value)
+        => int.TryParse(value, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeListMapping.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeListMapping.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// One rule from an entry's mapping list, correcting where the entry's episodes sit in the
+/// series the seasons are numbered by.
+/// </summary>
+/// <param name="AnidbSeason">1 when the numbers below are the entry's ordinary episodes, 0 when they are its specials.</param>
+/// <param name="TvdbSeason">The season the rule places them in.</param>
+/// <param name="Start">The first of the entry's episodes the rule covers, or <c>null</c> when it names episodes individually.</param>
+/// <param name="End">The last of the entry's episodes the rule covers.</param>
+/// <param name="Offset">Added to the entry's episode number to give the season's.</param>
+/// <param name="Pairs">Episodes named individually, from the entry's number to the season's. A season number of 0 means the episode has no counterpart there.</param>
+internal sealed record AniDbAnimeListMapping(
+    int AnidbSeason,
+    int TvdbSeason,
+    int? Start,
+    int? End,
+    int Offset,
+    IReadOnlyList<KeyValuePair<int, int>> Pairs);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbMappingOverrides.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbMappingOverrides.cs
@@ -1,0 +1,335 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+using MediaBrowser.Common.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// Mappings written by whoever runs the server, which answer before either downloaded source
+/// and are the last word on whatever they place.
+/// </summary>
+/// <remarks>
+/// Two shapes of library cannot be described by any source that describes AniDB as it is, and
+/// this is what states them:
+/// <list type="bullet">
+/// <item>
+/// A season or a show whose episodes AniDB files as another entry's other episodes. Berserk's
+/// Golden Age Arc Memorial Edition and Hellsing Ultimate Abridged are held that way, and a
+/// library that keeps either as a show of its own has nothing to be identified as.
+/// </item>
+/// <item>
+/// A specials season holding a special AniDB does not list at all - something shown at an event
+/// and never released. It leaves the season one longer than AniDB's own list, and the specials
+/// after it one out of step, which is enough to cost the whole season its numbering.
+/// </item>
+/// </list>
+/// <para>
+/// Written in the AniBridge schema, so that the reader for it does for both and there is no
+/// second format to learn: a file naming an entry's scope maps ranges of it onto ranges of a
+/// season, and the scope says which of the entry's numberings the range is read against.
+/// </para>
+/// </remarks>
+internal static class AniDbMappingOverrides
+{
+    /// <summary>
+    /// What the file is called. It sits beside the plugin's own configuration rather than in
+    /// the data folder, because it is written by hand and nothing here can fetch it again: the
+    /// data folder is a cache, and a cache is a thing people are told to empty.
+    /// </summary>
+    public const string FileName = "anidb-mapping-overrides.json";
+
+    private const string Description = "the mapping overrides";
+
+    private static readonly MappingSourceCache<AniBridgeIndex> _cache = new(
+        FileName,
+        null,
+        Description,
+        0,
+        (path, logger, writtenAtUtc) => AniBridgeIndex.Parse(path, logger, writtenAtUtc, Description),
+        appPaths => appPaths.PluginConfigurationsPath);
+
+    /// <summary>
+    /// The AniDB entries the given season is filled from, in the order its episodes run
+    /// through them.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="seasonNumber">The season number.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The segments, or <c>null</c> where the file does not place that season.</returns>
+    public static async Task<IReadOnlyList<AniDbSeasonSegment>?> ResolveSeason(
+        IApplicationPaths appPaths,
+        string seriesId,
+        int seasonNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (seasonNumber < 1)
+        {
+            return null;
+        }
+
+        var (index, siblings) = await FindShow(appPaths, seriesId, logger, cancellationToken).ConfigureAwait(false);
+
+        if (index == null || siblings == null)
+        {
+            return null;
+        }
+
+        var key = FormattableString.Invariant($"{seriesId}/{seasonNumber}");
+
+        if (index.Placements.TryGetValue(key, out var known))
+        {
+            return known.Count == 0 ? null : known;
+        }
+
+        var segments = AniBridgeIndex.Place(siblings, seasonNumber);
+
+        // At information rather than debug, and once per season: a placement written by hand is
+        // acted on ahead of everything else, so whoever wrote it should be able to see from an
+        // ordinary log that it was read and what it was taken to say.
+        if (index.Placements.TryAdd(key, segments) && segments.Count > 0)
+        {
+            logger.LogInformation(
+                "{Source} fill season {SeasonNumber} of AniDB series {SeriesId} with {Placement}",
+                Description,
+                seasonNumber,
+                seriesId,
+                string.Join(", ", segments.Select(SeasonSegments.Describe)));
+        }
+
+        return segments.Count == 0 ? null : segments;
+    }
+
+    /// <summary>
+    /// The AniDB entry a show begins in, found from the TVDB id another provider settled on.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="tvdbId">The TVDB id of the series.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB id, or <c>null</c> where the file places nothing against that id.</returns>
+    public static async Task<string?> ResolveSeriesId(
+        IApplicationPaths appPaths,
+        string? tvdbId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(tvdbId) || !tvdbId.All(char.IsAsciiDigit))
+        {
+            return null;
+        }
+
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.FirstSeasonByTvdb(tvdbId);
+    }
+
+    /// <summary>
+    /// The AniDB entry a show begins in, found from the TMDB id another provider settled on.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="tmdbId">The TMDB id of the series.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB id, or <c>null</c> where the file places nothing against that id.</returns>
+    public static async Task<string?> ResolveSeriesIdByTmdb(
+        IApplicationPaths appPaths,
+        string? tmdbId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(tmdbId) || !tmdbId.All(char.IsAsciiDigit))
+        {
+            return null;
+        }
+
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.FirstSeasonByTmdb(tmdbId);
+    }
+
+    /// <summary>
+    /// The AniDB entry a movie is, and which of its episodes holds it.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="key">The movie's key, from <see cref="MovieKey"/>.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The episode, or <c>null</c> where the file identifies no movie under that id.</returns>
+    public static async Task<AniDbAnimeListEpisode?> ResolveMovie(
+        IApplicationPaths appPaths,
+        string? key,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return null;
+        }
+
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.ResolveMovie(key);
+    }
+
+    /// <summary>
+    /// The entry a show begins in, given an entry of it the file places as a later season.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id the name match produced.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB id the show begins at, or <c>null</c> where the file does not place the entry or already places it first.</returns>
+    public static async Task<string?> ResolveFirstSeason(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(animeId))
+        {
+            return null;
+        }
+
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.WalkBackToFirstSeason(animeId);
+    }
+
+    /// <summary>
+    /// Where the given episode of the specials season is read from.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="episodeNumber">The episode number within the specials season.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The episode, or <c>null</c> where the file does not place it.</returns>
+    public static async Task<AniDbAnimeListEpisode?> ResolveSpecial(
+        IApplicationPaths appPaths,
+        string seriesId,
+        int episodeNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var (_, siblings) = await FindShow(appPaths, seriesId, logger, cancellationToken).ConfigureAwait(false);
+
+        if (siblings == null)
+        {
+            return null;
+        }
+
+        var placed = AniBridgeIndex.PlaceSpecial(siblings, episodeNumber);
+
+        if (placed != null)
+        {
+            logger.LogInformation(
+                "{Source} place special {EpisodeNumber} of AniDB series {SeriesId} at {EpisodeNumberInEntry} of anime {AnimeId}",
+                Description,
+                episodeNumber,
+                seriesId,
+                placed.Number,
+                placed.AnimeId);
+        }
+
+        return placed;
+    }
+
+    /// <summary>
+    /// Whether the file places the given entry in an ordinary season of a show, which makes its
+    /// silence about walking that entry back a statement rather than a gap.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of the entry.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><c>true</c> where the file places the entry in a season of its own.</returns>
+    public static async Task<bool> FilesInOrdinarySeason(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.FilesInOrdinarySeason(animeId) == true;
+    }
+
+    /// <summary>
+    /// What is known of the file, for the status the configuration page shows.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>Where the file belongs, when it was last written, how many entries, shows and movies have been read from it, and why it could not be read where it could not.</returns>
+    internal static async Task<(string Path, DateTime? WrittenAtUtc, int EntryCount, int ShowCount, int MovieCount, string? Error)> GetStatus(
+        IApplicationPaths appPaths,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        await _cache.GetIndex(appPaths, logger, cancellationToken, reread: true).ConfigureAwait(false);
+
+        var (writtenAtUtc, _, index, _, error) = _cache.GetStatus(appPaths);
+
+        // Movies counted apart because a file that names only movies places no season at all, and
+        // one reported as holding no entries would read as a file that had not been understood.
+        // Shows apart from entries because a show is what the file is written for, and the two
+        // seldom match: one show's season, its specials and its movie are three entries.
+        return (
+            _cache.GetPath(appPaths),
+            writtenAtUtc,
+            index?.EntryCount ?? 0,
+            index?.ShowCount ?? 0,
+            index?.MovieCount ?? 0,
+            error);
+    }
+
+    /// <summary>
+    /// The overrides, and the entries they file under the show the given series belongs to.
+    /// </summary>
+    /// <remarks>
+    /// Looked up by the entry first and by the show it belongs to second. A file written to
+    /// place a show nothing else places names the entry a season is read from, and that entry
+    /// is what the show is then identified as, so the entry alone is enough. A file written to
+    /// correct one season of a show the downloaded sources already place names only that
+    /// season's entry, which is not the entry the show was identified as, and there the show is
+    /// what the two have in common: whichever downloaded source placed the show says which TVDB
+    /// id its seasons are numbered against, and that is the id the overrides are keyed by.
+    /// </remarks>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The overrides and the show's entries, either of which may be <c>null</c>.</returns>
+    private static async Task<(AniBridgeIndex? Index, IReadOnlyList<AniBridgeEntry>? Siblings)> FindShow(
+        IApplicationPaths appPaths,
+        string seriesId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        if (index == null || string.IsNullOrEmpty(seriesId))
+        {
+            return (index, null);
+        }
+
+        var siblings = index.Siblings(seriesId);
+
+        if (siblings != null)
+        {
+            return (index, siblings);
+        }
+
+        var seriesKey = await AniDbMappings.ResolveSeriesKey(appPaths, seriesId, logger, cancellationToken).ConfigureAwait(false);
+
+        return (index, string.IsNullOrEmpty(seriesKey) ? null : index.EntriesFor(seriesKey));
+    }
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbMappings.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbMappings.cs
@@ -1,0 +1,353 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+using MediaBrowser.Common.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// The mapping sources, asked in order.
+/// </summary>
+/// <remarks>
+/// The AniBridge mappings are asked first. They place half again as many AniDB entries as the
+/// anime list, state each placement's episode ranges outright rather than leaving them to be
+/// worked out from an offset, and are built partly from the anime list itself, so where both
+/// place a show they are the later word on it. They also carry TMDB show ids, which the anime
+/// list has for movies only.
+/// <para>
+/// The anime list answers what AniBridge does not, which at the time of writing is 152 shows
+/// AniBridge maps to no TVDB id and a couple of hundred entries' specials. Each source's answer
+/// is self-consistent, and the primary answers whenever it can, so the two are only ever mixed
+/// for a show AniBridge places in part. That case is logged, because one of the two is wrong
+/// about it.
+/// </para>
+/// <para>
+/// Ahead of both sit <see cref="AniDbMappingOverrides"/>, written by whoever runs the server.
+/// Neither downloaded source can be corrected from here and neither describes a library that
+/// holds something AniDB does not list, so a file that states such a thing outright is the last
+/// word on whatever it names, and nothing on anything else.
+/// </para>
+/// </remarks>
+internal static class AniDbMappings
+{
+    private const string AniBridge = "the AniBridge mappings";
+    private const string AnimeList = "the anime list";
+    private const string Overrides = "the mapping overrides";
+
+    /// <summary>
+    /// How each source that places the given season says it is filled, best account first.
+    /// </summary>
+    /// <remarks>
+    /// Every source that places the season is offered, rather than only the first, because a
+    /// placement is a claim about entries that may not hold the episodes it claims. The caller
+    /// checks each against what AniDB records and takes the first that holds up, so that a
+    /// season one source is wrong about is still filled by the other. A placement from the
+    /// overrides is marked as the last word: the caller takes it wherever AniDB holds what it
+    /// names, and falls back to the sources below it only where AniDB does not.
+    /// </remarks>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="seasonNumber">The season number.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The placements, in the order they are worth trying, or empty when no source places the season.</returns>
+    public static async Task<IReadOnlyList<SeasonPlacement>> ResolveSeasons(
+        IApplicationPaths appPaths,
+        string seriesId,
+        int seasonNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var placements = new List<SeasonPlacement>(3);
+
+        void Offer(IReadOnlyList<AniDbSeasonSegment>? segments, string source, bool authoritative = false)
+        {
+            // Two sources agreeing is one placement, not two: the caller checks each against
+            // what AniDB records, and checking the same claim twice would only log it twice.
+            if (segments != null && !placements.Any(placement => placement.Segments.SequenceEqual(segments)))
+            {
+                placements.Add(new SeasonPlacement(segments, source, authoritative));
+            }
+        }
+
+        Offer(
+            await AniDbMappingOverrides.ResolveSeason(appPaths, seriesId, seasonNumber, logger, cancellationToken).ConfigureAwait(false),
+            Overrides,
+            true);
+
+        var bridged = await AniBridgeMappings.ResolveSeason(appPaths, seriesId, seasonNumber, logger, cancellationToken).ConfigureAwait(false);
+
+        Offer(bridged, AniBridge);
+
+        var listed = await AniDbAnimeList.ResolveSeason(appPaths, seriesId, seasonNumber, logger, cancellationToken).ConfigureAwait(false);
+
+        Offer(listed, AnimeList);
+
+        if (bridged == null && listed != null)
+        {
+            await ReportGap(appPaths, seriesId, seasonNumber, logger, cancellationToken).ConfigureAwait(false);
+        }
+
+        return placements;
+    }
+
+    /// <summary>
+    /// The AniDB entry a show begins in, found from whichever ids another provider has already
+    /// settled on. The TVDB id is tried first because both sources carry it, and a show placed
+    /// by both is placed against TVDB's numbering by both.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="tvdbId">The TVDB id of the series, where it has one.</param>
+    /// <param name="tmdbId">The TMDB id of the series, where it has one.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The show, or <c>null</c> when no source files anything under those ids.</returns>
+    public static async Task<MappedSeries?> ResolveSeriesId(
+        IApplicationPaths appPaths,
+        string? tvdbId,
+        string? tmdbId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var overridden = await AniDbMappingOverrides.ResolveSeriesId(appPaths, tvdbId, logger, cancellationToken).ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(overridden))
+        {
+            return new MappedSeries(overridden, Overrides, "TVDB", tvdbId!);
+        }
+
+        var bridged = await AniBridgeMappings.ResolveSeriesId(appPaths, tvdbId, logger, cancellationToken).ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(bridged))
+        {
+            return new MappedSeries(bridged, AniBridge, "TVDB", tvdbId!);
+        }
+
+        var listed = await AniDbAnimeList.ResolveSeriesId(appPaths, tvdbId, logger, cancellationToken).ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(listed))
+        {
+            return new MappedSeries(listed, AnimeList, "TVDB", tvdbId!);
+        }
+
+        // Only the overrides and AniBridge answer for TMDB, and both are asked after every
+        // source has been asked for TVDB: a show carrying both ids is better placed by the id
+        // its season numbering will be read against.
+        var overriddenByTmdb = await AniDbMappingOverrides.ResolveSeriesIdByTmdb(appPaths, tmdbId, logger, cancellationToken).ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(overriddenByTmdb))
+        {
+            return new MappedSeries(overriddenByTmdb, Overrides, "TMDB", tmdbId!);
+        }
+
+        var byTmdb = await AniBridgeMappings.ResolveSeriesIdByTmdb(appPaths, tmdbId, logger, cancellationToken).ConfigureAwait(false);
+
+        return string.IsNullOrEmpty(byTmdb) ? null : new MappedSeries(byTmdb, AniBridge, "TMDB", tmdbId!);
+    }
+
+    /// <summary>
+    /// The AniDB entry a movie is, found from whichever ids another provider has already settled
+    /// on, and which of that entry's episodes holds it.
+    /// </summary>
+    /// <remarks>
+    /// A movie has no seasons to be laid over, so an id is all there is to go on and every
+    /// source is asked for every id it might carry. The sources are asked in their own order
+    /// rather than the ids in theirs: which source answers decides what the movie is taken to
+    /// be, where which of its ids answered decides nothing.
+    /// <para>
+    /// Both downloaded sources identify a movie chiefly as an AniDB entry of its own. What the
+    /// overrides add is the other case: a movie AniDB holds inside an entry registered for
+    /// something else, as one of its other episodes or one of its specials.
+    /// </para>
+    /// </remarks>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="tmdbId">The TMDB movie id, where the item has one.</param>
+    /// <param name="imdbId">The IMDb id, where the item has one.</param>
+    /// <param name="tvdbId">The TVDB movie id, where the item has one.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The movie, or <c>null</c> when no source identifies one under those ids.</returns>
+    public static async Task<MappedMovie?> ResolveMovieId(
+        IApplicationPaths appPaths,
+        string? tmdbId,
+        string? imdbId,
+        string? tvdbId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        (string Provider, string? Id, string? Key)[] candidates =
+        [
+            ("TMDB", tmdbId, MovieKey.Tmdb(tmdbId)),
+            ("IMDb", imdbId, MovieKey.Imdb(imdbId)),
+            ("TVDB", tvdbId, MovieKey.Tvdb(tvdbId)),
+        ];
+
+        (string Name, Func<string?, Task<AniDbAnimeListEpisode?>> Resolve)[] sources =
+        [
+            (Overrides, key => AniDbMappingOverrides.ResolveMovie(appPaths, key, logger, cancellationToken)),
+            (AniBridge, key => AniBridgeMappings.ResolveMovie(appPaths, key, logger, cancellationToken)),
+            (AnimeList, key => AniDbAnimeList.ResolveMovie(appPaths, key, logger, cancellationToken)),
+        ];
+
+        foreach (var source in sources)
+        {
+            foreach (var candidate in candidates)
+            {
+                if (candidate.Key == null)
+                {
+                    continue;
+                }
+
+                var found = await source.Resolve(candidate.Key).ConfigureAwait(false);
+
+                if (found != null)
+                {
+                    return new MappedMovie(found, source.Name, candidate.Provider, candidate.Id!);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The entry a show begins in, given an entry of it that a source files as a later season.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id the name match produced.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB id the show begins at, or <c>null</c> where no source walks it back.</returns>
+    public static async Task<string?> ResolveFirstSeason(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var overridden = await AniDbMappingOverrides.ResolveFirstSeason(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(overridden))
+        {
+            return overridden;
+        }
+
+        var bridged = await AniBridgeMappings.ResolveFirstSeason(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(bridged))
+        {
+            return bridged;
+        }
+
+        // Not walked back by the anime list where AniBridge files the entry in a season of its
+        // own and left it there: AniBridge has already said the entry is a show's first season,
+        // and the two disagree about which show an entry belongs to often enough that overruling
+        // it here would hand the show to the wrong one. An entry AniBridge knows only as another
+        // show's specials is not such a statement, and is left to the anime list.
+        if (await AniDbMappingOverrides.FilesInOrdinarySeason(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false)
+            || await AniBridgeMappings.FilesInOrdinarySeason(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return await AniDbAnimeList.ResolveFirstSeason(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Where the given episode of the specials season may be read from, best guess first.
+    /// </summary>
+    /// <remarks>
+    /// Every source that places the episode is offered, rather than only the first, because a
+    /// placement is a claim about an entry that may not hold such an episode at all: the two
+    /// sources disagree about several hundred specials, and AniBridge alone claims some 2,300
+    /// that the anime list leaves to be matched against the show's own specials. A caller that
+    /// stopped at the first claim would lose a special the second source places correctly.
+    /// </remarks>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="episodeNumber">The episode number within the specials season.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The placements, in the order they are worth trying, or empty when no source places the episode.</returns>
+    public static async Task<IReadOnlyList<AniDbAnimeListEpisode>> ResolveSpecials(
+        IApplicationPaths appPaths,
+        string seriesId,
+        int episodeNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var placements = new List<AniDbAnimeListEpisode>(3);
+
+        void Offer(AniDbAnimeListEpisode? episode)
+        {
+            if (episode != null && !placements.Contains(episode))
+            {
+                placements.Add(episode);
+            }
+        }
+
+        Offer(await AniDbMappingOverrides.ResolveSpecial(appPaths, seriesId, episodeNumber, logger, cancellationToken).ConfigureAwait(false));
+        Offer(await AniBridgeMappings.ResolveSpecial(appPaths, seriesId, episodeNumber, logger, cancellationToken).ConfigureAwait(false));
+        Offer(await AniDbAnimeList.ResolveSpecial(appPaths, seriesId, episodeNumber, logger, cancellationToken).ConfigureAwait(false));
+
+        return placements;
+    }
+
+    /// <summary>
+    /// The show an entry belongs to, as the TVDB id whichever downloaded source places it
+    /// numbers its seasons against.
+    /// </summary>
+    /// <remarks>
+    /// What a sparsely written override file is reached through: it names the one entry a
+    /// season is to be read from, which is rarely the entry the show was identified as, so the
+    /// show the two have in common is the only thing that connects them.
+    /// </remarks>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The TVDB id, or <c>null</c> where no source places the entry against one.</returns>
+    public static async Task<string?> ResolveSeriesKey(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var bridged = await AniBridgeMappings.ResolveSeriesKey(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false);
+
+        return string.IsNullOrEmpty(bridged)
+            ? await AniDbAnimeList.ResolveSeriesKey(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false)
+            : bridged;
+    }
+
+    /// <summary>
+    /// Notes a season the anime list places and AniBridge does not, for a show AniBridge places
+    /// otherwise. One of the two is wrong about that show, and this is the only point at which
+    /// a season is filled from a source other than the one that identified the show.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="seasonNumber">The season number.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    private static async Task ReportGap(
+        IApplicationPaths appPaths,
+        string seriesId,
+        int seasonNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (await AniBridgeMappings.Places(appPaths, seriesId, logger, cancellationToken).ConfigureAwait(false))
+        {
+            logger.LogDebug(
+                "The AniBridge mappings place AniDB series {SeriesId} but not its season {SeasonNumber}, which {Source} filled instead",
+                seriesId,
+                seasonNumber,
+                AnimeList);
+        }
+    }
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/GitHubRelease.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/GitHubRelease.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// The GitHub releases API, asked which build a release is currently holding, so that a file
+/// already downloaded from it is not downloaded a second time.
+/// </summary>
+/// <remarks>
+/// A release is asked for by tag rather than by asking for the newest one there is. The tag
+/// names the schema of the file behind it and the reader here understands one schema, so a
+/// release cut for a later one must not be taken up on its own: it is adopted by raising the
+/// tag named in the source, alongside whatever the reader needs to understand it. What does
+/// move under a tag is the build attached to it - the mappings are rebuilt daily - and that is
+/// what this reports.
+/// </remarks>
+internal static class GitHubRelease
+{
+    /// <summary>
+    /// The named asset of the release under the given tag.
+    /// </summary>
+    /// <param name="httpClient">The client to ask with, which must carry a user agent: the API refuses a request without one.</param>
+    /// <param name="owner">The account the repository belongs to.</param>
+    /// <param name="repository">The repository the release is in.</param>
+    /// <param name="tag">The tag of the release.</param>
+    /// <param name="assetName">The file name of the asset.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>Where to download the asset and what identifies this build of it, or <c>null</c> where the release carries no asset of that name.</returns>
+    public static async Task<MappingSourceBuild?> ResolveAsset(
+        HttpClient httpClient,
+        string owner,
+        string repository,
+        string tag,
+        string assetName,
+        CancellationToken cancellationToken)
+    {
+        var url = new Uri(FormattableString.Invariant($"https://api.github.com/repos/{owner}/{repository}/releases/tags/{tag}"));
+
+        using (var request = new HttpRequestMessage(HttpMethod.Get, url))
+        {
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+            request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+
+            using (var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
+            {
+                response.EnsureSuccessStatusCode();
+
+                using (var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
+                using (var document = await JsonDocument.ParseAsync(stream, default, cancellationToken).ConfigureAwait(false))
+                {
+                    return FindAsset(document, tag, assetName);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The asset of that name among the release's own, as the API describes them.
+    /// </summary>
+    /// <param name="document">The release, as the API returned it.</param>
+    /// <param name="tag">The tag of the release, which goes into the version so that raising the tag counts as a new build whatever the assets under it are.</param>
+    /// <param name="assetName">The file name of the asset.</param>
+    /// <returns>The asset, or <c>null</c> where the release carries none of that name.</returns>
+    private static MappingSourceBuild? FindAsset(JsonDocument document, string tag, string assetName)
+    {
+        if (!document.RootElement.TryGetProperty("assets", out var assets) || assets.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var asset in assets.EnumerateArray())
+        {
+            if (asset.ValueKind != JsonValueKind.Object
+                || !asset.TryGetProperty("name", out var name)
+                || !string.Equals(name.GetString(), assetName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!asset.TryGetProperty("browser_download_url", out var downloadUrl)
+                || downloadUrl.GetString() is not { Length: > 0 } address)
+            {
+                return null;
+            }
+
+            // A rolling tag keeps its name and its publication date while its assets are
+            // replaced under it, so neither says which build this is. The asset does: it is
+            // given a new id and a new timestamp every time it is uploaded again.
+            var id = asset.TryGetProperty("id", out var identifier) && identifier.TryGetInt64(out var value)
+                ? value
+                : 0;
+            var updatedAt = asset.TryGetProperty("updated_at", out var updated) ? updated.GetString() : null;
+
+            return new MappingSourceBuild(address, FormattableString.Invariant($"{tag}/{id}/{updatedAt}"));
+        }
+
+        return null;
+    }
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappedMovie.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappedMovie.cs
@@ -1,0 +1,10 @@
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// A movie identified from an id another provider had already settled on, and what identified it.
+/// </summary>
+/// <param name="Episode">The AniDB entry the movie is, and which of its episodes holds it. A movie AniDB registers in its own right is that entry's first ordinary episode; one it holds inside another entry is a later episode, or a special, or one of the other episodes.</param>
+/// <param name="Source">Which mapping source answered, as a noun phrase for a log message.</param>
+/// <param name="Provider">Which provider's id it was found from.</param>
+/// <param name="ProviderId">That id.</param>
+internal sealed record MappedMovie(AniDbAnimeListEpisode Episode, string Source, string Provider, string ProviderId);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappedSeries.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappedSeries.cs
@@ -1,0 +1,10 @@
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// A show identified from an id another provider had already settled on, and what identified it.
+/// </summary>
+/// <param name="AnimeId">The AniDB id the show begins at.</param>
+/// <param name="Source">Which mapping source answered, as a noun phrase for a log message.</param>
+/// <param name="Provider">Which provider's id it was found from.</param>
+/// <param name="ProviderId">That id.</param>
+internal sealed record MappedSeries(string AnimeId, string Source, string Provider, string ProviderId);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappingSourceBuild.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappingSourceBuild.cs
@@ -1,0 +1,9 @@
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// Which build of a downloaded mapping file its source is currently holding: where to fetch it
+/// from, and what tells that build apart from the one before it.
+/// </summary>
+/// <param name="Url">Where the build is downloaded from, which for a release asset is the URL of the build rather than of the source.</param>
+/// <param name="Version">What identifies the build, or <c>null</c> where the source said nothing about which build it is holding.</param>
+internal sealed record MappingSourceBuild(string Url, string? Version);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappingSourceCache.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappingSourceCache.cs
@@ -1,0 +1,552 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Identity;
+using MediaBrowser.Common.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// One mapping file, and whatever was parsed from it. A file with a URL is fetched when the
+/// copy on disk is missing or has gone stale; one without is only ever read, being written by
+/// whoever runs the server. Either is parsed once per copy, and what came out of it is kept in
+/// memory until that copy changes underneath it.
+/// </summary>
+/// <typeparam name="TIndex">What the file is parsed into. Placements worked out from one copy belong to it, so anything memoised per lookup belongs on this rather than beside the cache.</typeparam>
+/// <param name="fileName">What the copy on disk is called, within the folder named below.</param>
+/// <param name="url">Where the file is downloaded from, or <c>null</c> for a file nobody downloads: one written by hand, which is allowed not to be there and is never thrown away.</param>
+/// <param name="description">How the file is named in log messages, as a noun phrase: "the anime list".</param>
+/// <param name="maxAgeDays">How long a downloaded copy is used before it is fetched again. Means nothing for a file that is not downloaded.</param>
+/// <param name="parse">Reads a copy on disk, given its path, a logger and the time it was written.</param>
+/// <param name="folder">Where the file lives, given the application paths. Defaults to the plugin's data folder, which is where a downloaded copy belongs.</param>
+/// <param name="resolve">Asks the source which build it is currently holding, for a source that can be asked outright: a GitHub release names the asset attached to it. Where this is <c>null</c> the question is put to the server as part of the download instead, by offering back the entity tag the last one answered with, and the file is sent again only where it has changed.</param>
+internal sealed class MappingSourceCache<TIndex>(
+    string fileName,
+    string? url,
+    string description,
+    int maxAgeDays,
+    Func<string, ILogger, DateTime, TIndex> parse,
+    Func<IApplicationPaths, string>? folder = null,
+    Func<HttpClient, CancellationToken, Task<MappingSourceBuild?>>? resolve = null)
+    : IDisposable
+    where TIndex : class
+{
+    /// <summary>
+    /// How long to wait before trying again once the file could not be read at all. Without a
+    /// pause a scan would ask for it once per series and fail every time; without a retry a
+    /// server that started while its network was down would never get the file.
+    /// </summary>
+    private readonly TimeSpan _retryAfterFailure = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// How long the copy in memory is used before the cached file is looked at again. Reading
+    /// the file's timestamp is cheap, but a scan asks once per episode, and the file only
+    /// changes when this class downloads it or someone replaces it by hand.
+    /// </summary>
+    private readonly TimeSpan _recheckInterval = TimeSpan.FromMinutes(5);
+
+    private readonly SemaphoreSlim _loadGate = new(1, 1);
+
+    /// <summary>
+    /// What was parsed from the copy on disk. Every lookup is answered from here.
+    /// </summary>
+    private TIndex? _index;
+
+    private DateTime _failedAtUtc = DateTime.MinValue;
+
+    /// <summary>
+    /// When the cached file was last compared against the copy in memory, and the timestamp of
+    /// the copy last read - whether or not it could be parsed. A server left running for weeks
+    /// would otherwise keep what it read at startup for as long as it ran, never learning where
+    /// the season that started since belongs, nor noticing a file replaced underneath it.
+    /// </summary>
+    private DateTime _checkedAtUtc = DateTime.MinValue;
+    private DateTime _sourceWrittenAtUtc = DateTime.MinValue;
+
+    /// <summary>
+    /// Why the copy on disk could not be read, or <c>null</c> where it was read. Kept so that
+    /// the configuration page can say a file written by hand is broken: whoever wrote it is
+    /// looking at that page rather than at the log.
+    /// </summary>
+    private string? _error;
+
+    /// <summary>
+    /// Gets how long a downloaded copy is used before it is fetched again.
+    /// </summary>
+    public int MaxAgeInDays => maxAgeDays;
+
+    /// <summary>
+    /// Gets how long to wait before looking at a file that could not be read again. A
+    /// downloaded one is waited out: nothing here can mend it, and the next attempt is a fresh
+    /// download. A file written by hand is mended by editing it, which is a minute's work, so
+    /// it is looked at again as often as any other change to it would be noticed.
+    /// </summary>
+    private TimeSpan RetryPause => url == null ? _recheckInterval : _retryAfterFailure;
+
+    /// <summary>
+    /// What the file holds, downloading and parsing it where what is in memory will not do.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="reread">Whether to look at the file even where what is in memory would otherwise do. For the configuration page, which is asked what the file on disk says now rather than what it said when the last episode was scanned. Means nothing for a downloaded file.</param>
+    /// <returns>The parsed file, or <c>null</c> when it could not be read.</returns>
+    public async Task<TIndex?> GetIndex(IApplicationPaths appPaths, ILogger logger, CancellationToken cancellationToken, bool reread = false)
+    {
+        // A re-read looks at the file whatever the interval says, but never at one that is
+        // downloaded: there it would mean a download, and the page that asks for it is polled.
+        var lookNow = reread && url == null;
+
+        // The common path, taken once per lookup: the file is already in memory and current.
+        if (!lookNow && IsCurrent())
+        {
+            return _index;
+        }
+
+        await _loadGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            if (!lookNow && IsCurrent())
+            {
+                return _index;
+            }
+
+            var path = GetPath(appPaths);
+
+            await Refresh(path, logger, cancellationToken).ConfigureAwait(false);
+
+            Reload(path, logger);
+        }
+        catch (IOException ex)
+        {
+            _failedAtUtc = DateTime.UtcNow;
+
+            logger.LogWarning(ex, "Could not read {Source}, so whatever it would have placed is placed some other way", description);
+        }
+        finally
+        {
+            _loadGate.Release();
+        }
+
+        return _index;
+    }
+
+    /// <summary>
+    /// Asks the source what it holds now, whatever the age of the copy cached, and downloads
+    /// and reads it where that is not the copy already on disk. For the button on the
+    /// configuration page: everything else waits the maximum age out, which is what keeps a
+    /// scan from asking the source once per episode.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>What the check came to.</returns>
+    public async Task<MappingSourceCheck> CheckNow(IApplicationPaths appPaths, ILogger logger, CancellationToken cancellationToken)
+    {
+        if (url == null)
+        {
+            // Nothing to ask: a file written by hand is read again within minutes of being
+            // changed, which is a check of its own and needs no button.
+            return MappingSourceCheck.NotDownloaded;
+        }
+
+        await _loadGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            var path = GetPath(appPaths);
+            var outcome = await Refresh(path, logger, cancellationToken, force: true).ConfigureAwait(false);
+
+            // Read here rather than at the next lookup, so that the page which asked for the
+            // check is answered with what came of it: a copy downloaded but unreadable is
+            // worth saying now, and the entry count it reports is the new copy's.
+            Reload(path, logger);
+
+            return _error == null ? outcome : MappingSourceCheck.Failed;
+        }
+        catch (IOException ex)
+        {
+            _failedAtUtc = DateTime.UtcNow;
+
+            logger.LogWarning(ex, "Could not read {Source}, so whatever it would have placed is placed some other way", description);
+
+            return MappingSourceCheck.Failed;
+        }
+        finally
+        {
+            _loadGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Reads the copy on disk into memory where it is not the copy already read. Called under
+    /// the load gate, with whatever the refresh left on disk.
+    /// </summary>
+    /// <param name="path">Where the file is cached.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    private void Reload(string path, ILogger logger)
+    {
+        var file = new FileInfo(path);
+
+        if (!file.Exists || file.Length == 0)
+        {
+            // No file at all is the ordinary state of one written by hand, so it is noted
+            // as looked at rather than as failed. Noting it is what keeps a scan from
+            // asking the file system once per episode, and the recheck interval is what
+            // brings a file written since into use without a restart.
+            if (url == null)
+            {
+                _index = null;
+                _error = null;
+                _sourceWrittenAtUtc = DateTime.MinValue;
+                _checkedAtUtc = DateTime.UtcNow;
+
+                return;
+            }
+
+            _failedAtUtc = DateTime.UtcNow;
+
+            return;
+        }
+
+        // The file is the copy of record. Where it is the one already read there is nothing
+        // to do; where it is not - downloaded just now, or replaced by hand - what is in
+        // memory is out of date whatever its own age. Read rather than parsed, so that a
+        // file which would not parse is not parsed again on every look.
+        if (file.LastWriteTimeUtc == _sourceWrittenAtUtc)
+        {
+            _checkedAtUtc = DateTime.UtcNow;
+
+            return;
+        }
+
+        try
+        {
+            _index = parse(path, logger, file.LastWriteTimeUtc);
+            _error = null;
+            _checkedAtUtc = DateTime.UtcNow;
+            _sourceWrittenAtUtc = file.LastWriteTimeUtc;
+        }
+        catch (Exception ex) when (ex is XmlException or JsonException)
+        {
+            _error = ex.Message;
+
+            if (url == null)
+            {
+                // Not this class's to throw away: it is the only copy there is. It stays
+                // where it is, and nothing new is taken from it - a copy read before this
+                // one goes on being used, an edit half written having broken it - until it
+                // is fixed.
+                logger.LogError(ex, "{Source} at {Path} is not valid JSON, so nothing new is taken from it. Fix or remove the file", description, path);
+
+                // Noted as read so that the same broken copy is not parsed again on every
+                // look, the configuration page asking for one every few seconds.
+                _checkedAtUtc = DateTime.UtcNow;
+                _sourceWrittenAtUtc = file.LastWriteTimeUtc;
+            }
+            else
+            {
+                // A truncated or half-written file would otherwise be read again on every
+                // start until it went stale. Dropping it means the next start downloads afresh.
+                logger.LogWarning(ex, "The cached copy of {Source} at {Path} could not be read and has been discarded", description, path);
+
+                TryDelete(path);
+                MappingSourceMarker.Delete(path);
+            }
+
+            _failedAtUtc = DateTime.UtcNow;
+        }
+    }
+
+    /// <summary>
+    /// What is known of the file, for the status the configuration page shows. Reads nothing
+    /// but its timestamp, so it costs little to ask often.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <returns>When the cached copy was downloaded, when the source was last asked whether it holds a newer one, what was parsed from the copy, how many days one is used for, and why the copy on disk could not be read where it could not.</returns>
+    public (DateTime? CachedAtUtc, DateTime? CheckedAtUtc, TIndex? Index, int MaxAgeInDays, string? Error) GetStatus(IApplicationPaths appPaths)
+    {
+        DateTime? cachedAtUtc = null;
+        DateTime? checkedAtUtc = null;
+
+        try
+        {
+            var path = GetPath(appPaths);
+            var file = new FileInfo(path);
+
+            if (file.Exists && file.Length > 0)
+            {
+                cachedAtUtc = file.LastWriteTimeUtc;
+
+                // Worth reporting apart from the download: a check that finds the newest build
+                // already cached leaves the copy's own date where it was, and a page showing
+                // only that would read as a source that had stopped being looked at.
+                checkedAtUtc = MappingSourceMarker.Read(path)?.CheckedAtUtc;
+            }
+        }
+        catch (IOException)
+        {
+            // The status is worth less than the page it is shown on.
+        }
+
+        return (cachedAtUtc, checkedAtUtc, _index, maxAgeDays, _error);
+    }
+
+    /// <summary>
+    /// Releases the gate that keeps two lookups from downloading or parsing at once. Each
+    /// source is held for as long as the plugin is loaded, so this is for the analyzer's sake
+    /// rather than for a caller's.
+    /// </summary>
+    public void Dispose() => _loadGate.Dispose();
+
+    /// <summary>
+    /// Whether a lookup may be answered from what is in memory, either because the cached file
+    /// was checked against it recently enough or because reading it failed recently enough to
+    /// be worth a pause.
+    /// </summary>
+    /// <returns><c>true</c> when the cached file need not be looked at.</returns>
+    private bool IsCurrent()
+    {
+        var now = DateTime.UtcNow;
+
+        // Checked against the time of the last look rather than against what it produced: a
+        // look that found no file is as good an answer as one that found a whole mapping set.
+        return now - _failedAtUtc < RetryPause
+            || (_checkedAtUtc != DateTime.MinValue && now - _checkedAtUtc < _recheckInterval);
+    }
+
+    /// <summary>
+    /// Where the file is. Public so that a page can tell the user where to put one they write
+    /// themselves.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <returns>The full path.</returns>
+    public string GetPath(IApplicationPaths appPaths)
+        => Path.Combine(folder == null ? AniDbTitleDownloader.GetDataPath(appPaths) : folder(appPaths), fileName);
+
+    /// <summary>
+    /// Asks the source what it holds once the copy on disk has gone stale, and downloads it
+    /// where that is not the copy already cached. A copy that is merely stale is kept when the
+    /// source cannot be reached: an old mapping for a show already in the library is almost
+    /// always still the right one, and is certainly better than none.
+    /// </summary>
+    /// <param name="path">Where the file is cached.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="force">Whether to ask the source however lately it was last asked. For a check asked for by hand, which is the one case where waiting the maximum age out is not what was wanted.</param>
+    /// <returns>What the check came to.</returns>
+    private async Task<MappingSourceCheck> Refresh(string path, ILogger logger, CancellationToken cancellationToken, bool force = false)
+    {
+        if (url == null)
+        {
+            return MappingSourceCheck.NotDownloaded;
+        }
+
+        var file = new FileInfo(path);
+        var cached = file.Exists && file.Length > 0;
+        var marker = cached ? MappingSourceMarker.Read(path) : null;
+
+        // Counted from the last time the source was asked rather than from the download,
+        // because a check that finds the newest build already cached leaves the copy on disk
+        // untouched: dating it by its own timestamp would ask again on every lookup for the
+        // rest of the week. A copy cached before any of this was recorded has only its
+        // timestamp to go by.
+        var askedAtUtc = marker?.CheckedAtUtc ?? file.LastWriteTimeUtc;
+
+        if (cached && !force && (DateTime.UtcNow - askedAtUtc).TotalDays <= maxAgeDays)
+        {
+            return MappingSourceCheck.Unchanged;
+        }
+
+        // Not paced by the AniDB request gate: this comes from the file's own host, and holding
+        // up a scan behind AniDB's rate limit for it would be for nothing.
+        var httpClient = Plugin.Instance.GetHttpClient();
+        var known = cached ? marker?.Version : null;
+
+        try
+        {
+            var build = await Resolve(httpClient, logger, cancellationToken).ConfigureAwait(false);
+
+            // The source named the build it holds and it is the one already on disk, so there
+            // is nothing to fetch: only the date it was last asked about moves on.
+            if (known != null && build?.Version != null && string.Equals(known, build.Version, StringComparison.Ordinal))
+            {
+                logger.LogInformation(
+                    "Not downloading {Source} again: the source still holds the build cached on {CachedAt}",
+                    description,
+                    file.LastWriteTimeUtc);
+
+                MappingSourceMarker.Write(path, known);
+
+                return MappingSourceCheck.Unchanged;
+            }
+
+            // Only the plain URL asks the server: where the build was resolved above, the
+            // question has been answered already and the entity tag of the last download is
+            // the tag of a different address.
+            var (downloaded, version) = await Download(
+                build?.Url ?? url,
+                path,
+                build == null ? known : null,
+                httpClient,
+                logger,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!downloaded)
+            {
+                logger.LogInformation(
+                    "Not downloading {Source} again: it is unchanged since the copy cached on {CachedAt}",
+                    description,
+                    file.LastWriteTimeUtc);
+            }
+
+            MappingSourceMarker.Write(path, build?.Version ?? version);
+
+            return downloaded ? MappingSourceCheck.Updated : MappingSourceCheck.Unchanged;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException or TaskCanceledException or JsonException)
+        {
+            if (!cached)
+            {
+                throw new IOException(FormattableString.Invariant($"{description} could not be downloaded and no copy is cached"), ex);
+            }
+
+            logger.LogWarning(
+                ex,
+                "{Source} could not be downloaded, so the copy cached on {CachedAt} is used instead",
+                description,
+                file.LastWriteTimeUtc);
+
+            return MappingSourceCheck.Failed;
+        }
+    }
+
+    /// <summary>
+    /// Asks the source which build it is currently holding, for a source that can be asked.
+    /// </summary>
+    /// <param name="httpClient">The client to ask with.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The build, or <c>null</c> where the source cannot be asked or would not say.</returns>
+    private async Task<MappingSourceBuild?> Resolve(HttpClient httpClient, ILogger logger, CancellationToken cancellationToken)
+    {
+        if (resolve == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var build = await resolve(httpClient, cancellationToken).ConfigureAwait(false);
+
+            if (build != null)
+            {
+                return build;
+            }
+
+            logger.LogWarning(
+                "The source of {Source} does not name the build it is holding, so it is downloaded from {Url} without asking",
+                description,
+                url);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException or TaskCanceledException or JsonException)
+        {
+            // Asking is what saves the download, not what makes it possible: the URL names the
+            // same file either way. GitHub's API is rate limited per address and this is the
+            // only thing here that uses it, so a refusal is answered by fetching outright
+            // rather than by leaving the copy on disk to go on ageing.
+            logger.LogWarning(
+                ex,
+                "Could not ask which build of {Source} is current, so it is downloaded from {Url} without asking",
+                description,
+                url);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Fetches the file, unless the server answers that the copy already cached is the current
+    /// one.
+    /// </summary>
+    /// <param name="sourceUrl">Where to fetch it from.</param>
+    /// <param name="path">Where the file is cached.</param>
+    /// <param name="knownVersion">The entity tag the last download answered with, to be offered back so that an unchanged file is not sent again, or <c>null</c> to fetch outright.</param>
+    /// <param name="httpClient">The client to fetch with.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>Whether the copy on disk was replaced, and what identifies what is now cached.</returns>
+    private async Task<(bool Downloaded, string? Version)> Download(
+        string sourceUrl,
+        string path,
+        string? knownVersion,
+        HttpClient httpClient,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        using (var request = new HttpRequestMessage(HttpMethod.Get, new Uri(sourceUrl)))
+        {
+            if (knownVersion != null)
+            {
+                request.Headers.TryAddWithoutValidation("If-None-Match", knownVersion);
+            }
+
+            using (var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false))
+            {
+                if (response.StatusCode == HttpStatusCode.NotModified)
+                {
+                    return (false, knownVersion);
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                logger.LogInformation("Downloading {Source} from {Url}", description, sourceUrl);
+
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+                var temporaryFile = path + ".tmp";
+
+                try
+                {
+                    using (var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false))
+                    using (var writer = File.Open(temporaryFile, FileMode.Create, FileAccess.Write))
+                    {
+                        await stream.CopyToAsync(writer, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    File.Move(temporaryFile, path, true);
+                }
+                catch
+                {
+                    TryDelete(temporaryFile);
+
+                    throw;
+                }
+
+                // Offered back on the next check, where nothing else names the build: the
+                // server answers an unchanged file with "not modified" rather than with the
+                // file, which for the anime list is the only way to ask at all.
+                return (true, response.Headers.ETag?.ToString());
+            }
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // The next start tries again.
+        }
+    }
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappingSourceCheck.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappingSourceCheck.cs
@@ -1,0 +1,35 @@
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// What asking a mapping source what it holds came to, for the page that asked for it.
+/// </summary>
+internal enum MappingSourceCheck
+{
+    /// <summary>
+    /// The source holds what is already cached, so nothing was downloaded.
+    /// </summary>
+    Unchanged = 0,
+
+    /// <summary>
+    /// The source held something newer, and it has been downloaded and read.
+    /// </summary>
+    Updated = 1,
+
+    /// <summary>
+    /// The source could not be reached, or what came back could not be read. Whatever was
+    /// cached before is still being used.
+    /// </summary>
+    Failed = 2,
+
+    /// <summary>
+    /// Nothing downloads the file: it is written by whoever runs the server, and is read again
+    /// within minutes of being changed rather than being checked for.
+    /// </summary>
+    NotDownloaded = 3,
+
+    /// <summary>
+    /// The source is switched off in the configuration, so it is not consulted and there is no
+    /// reason to fetch it.
+    /// </summary>
+    NotUsed = 4
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappingSourceMarker.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappingSourceMarker.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// What is known of a downloaded mapping file beyond the copy itself: which build of the source
+/// that copy is, and when the source was last asked whether it holds a newer one. Kept in a
+/// small file beside the copy, so that emptying the cache by hand leaves nothing behind that
+/// would be believed about a file no longer there.
+/// </summary>
+internal sealed class MappingSourceMarker
+{
+    private static readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Gets or sets what identifies the cached build, as its source named it: the release asset
+    /// a rolling tag currently carries, or the entity tag a plain URL answered with. Nothing
+    /// here reads it, so which of the two it is does not matter - only whether the source still
+    /// names the same one.
+    /// </summary>
+    public string? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the source was last asked what it holds, whether or not that produced
+    /// a download. This is what the maximum age is counted from: a check that found nothing new
+    /// leaves the copy on disk untouched, and dating the copy by its own timestamp would ask
+    /// again on every lookup for the rest of the week.
+    /// </summary>
+    public DateTime CheckedAtUtc { get; set; }
+
+    /// <summary>
+    /// The marker beside the given cached copy.
+    /// </summary>
+    /// <param name="path">Where the cached copy is.</param>
+    /// <returns>The marker, or <c>null</c> where there is none or it could not be read. It is only ever a shortcut past a download, so one that will not parse is treated as one that is not there.</returns>
+    public static MappingSourceMarker? Read(string path)
+    {
+        try
+        {
+            var markerPath = PathFor(path);
+
+            if (!File.Exists(markerPath))
+            {
+                return null;
+            }
+
+            return JsonSerializer.Deserialize<MappingSourceMarker>(File.ReadAllBytes(markerPath), _options);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Records that the source was asked just now, and that what is cached is the given build.
+    /// </summary>
+    /// <param name="path">Where the cached copy is.</param>
+    /// <param name="version">What identifies the cached build, or <c>null</c> where the source named none.</param>
+    public static void Write(string path, string? version)
+    {
+        try
+        {
+            var marker = new MappingSourceMarker { Version = version, CheckedAtUtc = DateTime.UtcNow };
+
+            File.WriteAllBytes(PathFor(path), JsonSerializer.SerializeToUtf8Bytes(marker, _options));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Costs a download that need not have happened, and nothing else: the next check
+            // finds no marker and asks the source outright.
+        }
+    }
+
+    /// <summary>
+    /// Forgets what was known of a copy that is being thrown away, so that the copy downloaded
+    /// in its place is not taken for the build this one was.
+    /// </summary>
+    /// <param name="path">Where the cached copy was.</param>
+    public static void Delete(string path)
+    {
+        try
+        {
+            File.Delete(PathFor(path));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // The version it names is compared against the source's before it is trusted, so
+            // one left behind costs at worst a download that was not needed.
+        }
+    }
+
+    private static string PathFor(string path) => path + ".state.json";
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MovieKey.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MovieKey.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// How a movie is keyed across the mapping sources, so that all of them file one under the same
+/// string whatever each calls it: AniBridge writes "tmdb_movie:128", the anime list writes a
+/// tmdbid attribute, and Jellyfin holds the same id under its own provider name.
+/// </summary>
+internal static class MovieKey
+{
+    /// <summary>
+    /// The key for a TMDB movie id.
+    /// </summary>
+    /// <param name="id">The id, as the provider wrote it.</param>
+    /// <returns>The key, or <c>null</c> where that is not an id.</returns>
+    public static string? Tmdb(string? id) => Numeric("tmdb", id);
+
+    /// <summary>
+    /// The key for a TVDB movie id, which TVDB numbers separately from its series.
+    /// </summary>
+    /// <param name="id">The id, as the provider wrote it.</param>
+    /// <returns>The key, or <c>null</c> where that is not an id.</returns>
+    public static string? Tvdb(string? id) => Numeric("tvdb", id);
+
+    /// <summary>
+    /// The key for an IMDb title id.
+    /// </summary>
+    /// <param name="id">The id, as the provider wrote it.</param>
+    /// <returns>The key, or <c>null</c> where that is not an id.</returns>
+    public static string? Imdb(string? id)
+    {
+        var trimmed = id?.Trim();
+
+        // "tt" and at least one digit. The anime list carries a few ids written some other way,
+        // and a key made from one of those would never be asked for.
+        if (trimmed == null || trimmed.Length <= 2 || !trimmed.StartsWith("tt", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        foreach (var character in trimmed.AsSpan(2))
+        {
+            if (!char.IsAsciiDigit(character))
+            {
+                return null;
+            }
+        }
+
+        // Lowercased, because a provider writing the prefix in capitals is writing the same id.
+        return "imdb:" + trimmed.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// The key an AniBridge movie descriptor names, which is "&lt;provider&gt;_movie:&lt;id&gt;".
+    /// </summary>
+    /// <param name="descriptor">The descriptor as written.</param>
+    /// <returns>The key, or <c>null</c> where the descriptor does not name a movie this reads.</returns>
+    public static string? FromDescriptor(string descriptor)
+    {
+        var parts = descriptor.Split(':');
+
+        if (parts.Length != 2)
+        {
+            return null;
+        }
+
+        return parts[0] switch
+        {
+            "tmdb_movie" => Tmdb(parts[1]),
+            "imdb_movie" => Imdb(parts[1]),
+            "tvdb_movie" => Tvdb(parts[1]),
+            _ => null,
+        };
+    }
+
+    private static string? Numeric(string provider, string? id)
+    {
+        var trimmed = id?.Trim();
+
+        return !string.IsNullOrEmpty(trimmed) && trimmed.All(char.IsAsciiDigit) ? provider + ":" + trimmed : null;
+    }
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/SeasonPlacement.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/SeasonPlacement.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// One mapping source's account of how a season is filled, and which source gave it.
+/// </summary>
+/// <param name="Segments">The entries the season is filled from, in the order its episodes run through them.</param>
+/// <param name="Source">Which source placed it, as a noun phrase for a log message.</param>
+/// <param name="Authoritative">Whether the placement is to be used as it stands wherever AniDB holds the episodes it names, rather than weighed against the other sources. True of a placement written by hand: the episodes it leaves out of a season are the ones its author left out, so measuring it against the length of the season would reject exactly the placements it exists to state.</param>
+internal sealed record SeasonPlacement(
+    IReadOnlyList<AniDbSeasonSegment> Segments,
+    string Source,
+    bool Authoritative = false);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/SeasonSegments.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/SeasonSegments.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// Puts the segments claiming one season into the order its episodes run through them. Both
+/// mapping sources produce their claims entry by entry, in no particular order, and neither
+/// always says how long a claim is.
+/// </summary>
+internal static class SeasonSegments
+{
+    /// <summary>
+    /// The longest season this will lay out episode by episode. One Piece's longest is under two
+    /// hundred, so anything past this is a mapping to be taken whole rather than walked.
+    /// </summary>
+    private const int MaxEpisodesPerSeason = 2000;
+
+    /// <summary>
+    /// Orders the claims and gives each open-ended one the room up to the next.
+    /// </summary>
+    /// <param name="claims">The segments claiming the season, in any order.</param>
+    /// <returns>The segments, in the order the season's episodes run through them.</returns>
+    public static IReadOnlyList<AniDbSeasonSegment> Order(List<AniDbSeasonSegment> claims)
+    {
+        if (claims.Count == 0)
+        {
+            return [];
+        }
+
+        // A segment with no count has to come last among those starting together, or it would
+        // swallow the one after it.
+        var segments = claims
+            .OrderBy(segment => segment.FirstEpisodeNumber)
+            .ThenBy(segment => segment.EpisodeCount == 0 ? 1 : 0)
+            .ToList();
+
+        // An entry only runs to the end of the season if no other entry starts later in it. A
+        // season released in parts is one entry per part, each saying where it starts and none
+        // of them how long it is, so without this the first part would answer for the whole
+        // season and every episode past it would be looked up in the entry before its own.
+        for (var index = 0; index < segments.Count - 1; index++)
+        {
+            var room = segments[index + 1].FirstEpisodeNumber - segments[index].FirstEpisodeNumber;
+
+            if (segments[index].EpisodeCount == 0 && room > 0)
+            {
+                segments[index] = segments[index] with { EpisodeCount = room };
+            }
+        }
+
+        return segments;
+    }
+
+    /// <summary>
+    /// A segment written out for a log message.
+    /// </summary>
+    /// <param name="segment">The segment.</param>
+    /// <returns>The description.</returns>
+    public static string Describe(AniDbSeasonSegment segment)
+        => segment.EpisodeCount > 0
+            ? FormattableString.Invariant(
+                $"episodes {segment.FirstEpisodeNumber}-{segment.FirstEpisodeNumber + segment.EpisodeCount - 1} from anime {segment.AnimeId} episodes {segment.FirstEpisodeInEntry}-{segment.FirstEpisodeInEntry + segment.EpisodeCount - 1}")
+            : FormattableString.Invariant(
+                $"episodes {segment.FirstEpisodeNumber} onwards from anime {segment.AnimeId} episode {segment.FirstEpisodeInEntry} onwards");
+
+    /// <summary>
+    /// Settles the claims several of an entry's numberings make on one season.
+    /// </summary>
+    /// <remarks>
+    /// Two numberings of one entry usually describe different parts of a season rather than the
+    /// same part: K-On!'s first season is twelve ordinary episodes followed by two of the
+    /// entry's specials, and Bakemonogatari's is twelve followed by three. Taking one numbering
+    /// and dropping the other left those episodes unidentified.
+    /// <para>
+    /// Where two numberings do claim the same episode, one of them is a stub - anime 13473 maps
+    /// a single ordinary episode onto a season its other episodes describe in full, and anime
+    /// 11350 the reverse - so the numbering covering more of the season wins the episodes they
+    /// disagree about. On an even tie the one drawing on more of the entry's own episodes wins,
+    /// a season read from three episodes being better told than the same season read three times
+    /// from one, and ordinary episodes win from there.
+    /// </para>
+    /// </remarks>
+    /// <param name="claims">The claims on the season, by the numbering that made them.</param>
+    /// <returns>The segments, in the order the season's episodes run through them.</returns>
+    public static IReadOnlyList<AniDbSeasonSegment> Resolve(Dictionary<AniDbEpisodeKind, List<AniDbSeasonSegment>> claims)
+    {
+        if (claims.Count == 0)
+        {
+            return [];
+        }
+
+        return Order(claims.Count == 1 ? claims.First().Value : Merge(claims));
+    }
+
+    /// <summary>
+    /// Records a claim under the numbering it reads from.
+    /// </summary>
+    /// <param name="claims">The claims so far.</param>
+    /// <param name="segment">The claim.</param>
+    public static void Add(Dictionary<AniDbEpisodeKind, List<AniDbSeasonSegment>> claims, AniDbSeasonSegment segment)
+    {
+        if (!claims.TryGetValue(segment.Kind, out var byKind))
+        {
+            byKind = [];
+            claims[segment.Kind] = byKind;
+        }
+
+        byKind.Add(segment);
+    }
+
+    /// <summary>
+    /// How many of a season's episodes one numbering accounts for.
+    /// </summary>
+    /// <param name="segments">The claims that numbering made.</param>
+    /// <returns>The episode count, or <see cref="long.MaxValue"/> where a claim runs to the end of the season.</returns>
+    private static long Coverage(List<AniDbSeasonSegment> segments)
+    {
+        long covered = 0;
+
+        foreach (var segment in segments)
+        {
+            // A claim with no end accounts for the rest of the season whatever its length, and
+            // two of them must not be added together: counted as a number each, they overflowed.
+            if (segment.EpisodeCount <= 0)
+            {
+                return long.MaxValue;
+            }
+
+            covered += segment.EpisodeCount;
+        }
+
+        return covered;
+    }
+
+    private static List<AniDbSeasonSegment> Merge(Dictionary<AniDbEpisodeKind, List<AniDbSeasonSegment>> claims)
+    {
+        var ordered = claims
+            .OrderByDescending(pair => Coverage(pair.Value))
+            .ThenByDescending(pair => pair.Value.Select(segment => segment.FirstEpisodeInEntry).Distinct().Count())
+            .ThenBy(pair => pair.Key == AniDbEpisodeKind.Regular ? 0 : 1)
+            .ToList();
+
+        // A run with no end cannot be laid out episode by episode, and neither can a season of
+        // implausible length. Where one turns up, the numbering covering most of the season
+        // answers for the whole of it.
+        if (ordered.Exists(pair => pair.Value.Exists(segment => segment.EpisodeCount <= 0 || segment.EpisodeCount > MaxEpisodesPerSeason)))
+        {
+            return ordered[0].Value;
+        }
+
+        var placed = new Dictionary<int, AniDbSeasonSegment>();
+
+        foreach (var (_, segments) in ordered)
+        {
+            foreach (var segment in segments)
+            {
+                for (var offset = 0; offset < segment.EpisodeCount; offset++)
+                {
+                    var episode = segment.FirstEpisodeNumber + offset;
+
+                    // The first numbering to claim an episode keeps it.
+                    if (!placed.ContainsKey(episode))
+                    {
+                        placed[episode] = new AniDbSeasonSegment(
+                            segment.AnimeId,
+                            episode,
+                            1,
+                            segment.FirstEpisodeInEntry + offset,
+                            segment.Kind);
+                    }
+                }
+            }
+        }
+
+        var merged = new List<AniDbSeasonSegment>();
+
+        foreach (var episode in placed.Keys.Order())
+        {
+            var one = placed[episode];
+
+            // Episodes read consecutively from the same run of the same entry are one segment
+            // again, so that a season no other numbering interrupts is described as plainly as
+            // it was before.
+            if (merged.Count > 0
+                && merged[^1] is { } last
+                && string.Equals(last.AnimeId, one.AnimeId, StringComparison.Ordinal)
+                && last.Kind == one.Kind
+                && last.FirstEpisodeNumber + last.EpisodeCount == one.FirstEpisodeNumber
+                && last.FirstEpisodeInEntry + last.EpisodeCount == one.FirstEpisodeInEntry)
+            {
+                merged[^1] = last with { EpisodeCount = last.EpisodeCount + 1 };
+
+                continue;
+            }
+
+            merged.Add(one);
+        }
+
+        return merged;
+    }
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbAnimeSummary.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbAnimeSummary.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+/// <summary>
+/// The few fields of a cached AniDB anime document that are needed to decide whether that
+/// anime is the next season of another one.
+/// </summary>
+internal sealed class AniDbAnimeSummary
+{
+    /// <summary>
+    /// Gets the AniDB id of the anime.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Gets the AniDB format of the anime, such as "TV Series" or "OVA".
+    /// </summary>
+    public string? Type { get; init; }
+
+    /// <summary>
+    /// Gets the number of regular episodes AniDB records for the anime. Specials are not
+    /// counted, and an anime still airing is counted as the episodes it will have.
+    /// </summary>
+    public int EpisodeCount { get; init; }
+
+    /// <summary>
+    /// Gets the date the anime started airing.
+    /// </summary>
+    public DateTime? StartDate { get; init; }
+
+    /// <summary>
+    /// Gets the date the anime finished airing.
+    /// </summary>
+    public DateTime? EndDate { get; init; }
+
+    /// <summary>
+    /// Gets every title the anime is known by, in the order AniDB lists them.
+    /// </summary>
+    public IReadOnlyList<string> Titles { get; init; } = [];
+
+    /// <summary>
+    /// Gets the AniDB ids of the anime that AniDB relates to this one as a sequel.
+    /// </summary>
+    public IReadOnlyList<string> SequelIds { get; init; } = [];
+
+    /// <summary>
+    /// Gets the AniDB ids of the anime that AniDB relates to this one as a prequel. Relations
+    /// are recorded from both ends, so these confirm a link found any other way.
+    /// </summary>
+    public IReadOnlyList<string> PrequelIds { get; init; } = [];
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeKind.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeKind.cs
@@ -1,0 +1,26 @@
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+/// <summary>
+/// Which of an AniDB entry's episode numberings an episode belongs to. AniDB numbers each type
+/// separately and writes the type into the number itself, so "1", "S1" and "O1" are three
+/// different episodes of one entry.
+/// </summary>
+internal enum AniDbEpisodeKind
+{
+    /// <summary>
+    /// An ordinary episode, numbered from 1.
+    /// </summary>
+    Regular,
+
+    /// <summary>
+    /// A special, numbered from S1.
+    /// </summary>
+    Special,
+
+    /// <summary>
+    /// One of AniDB's other episodes, numbered from O1. A movie released as a season and
+    /// broadcast as a run of television episodes is recorded twice: as the entry's ordinary
+    /// episodes, one per movie, and again here, one per broadcast episode.
+    /// </summary>
+    Other
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeKindExtensions.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeKindExtensions.cs
@@ -1,0 +1,20 @@
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+/// <summary>
+/// Extension methods for <see cref="AniDbEpisodeKind"/>.
+/// </summary>
+internal static class AniDbEpisodeKindExtensions
+{
+    /// <summary>
+    /// What AniDB puts before the number of an episode of this kind, which is also what the
+    /// cached document of one is named after.
+    /// </summary>
+    /// <param name="kind">The kind.</param>
+    /// <returns>The prefix, which is empty for an ordinary episode.</returns>
+    public static string Prefix(this AniDbEpisodeKind kind) => kind switch
+    {
+        AniDbEpisodeKind.Special => "S",
+        AniDbEpisodeKind.Other => "O",
+        _ => string.Empty,
+    };
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
@@ -211,7 +211,7 @@ public class AniDbEpisodeProvider(IServerConfigurationManager configurationManag
             }
         }
 
-        var title = titles.Localize(Configuration.TitlePreferenceType.Localized, preferredMetadataLanguage)?.Name;
+        var title = titles.Localize(Plugin.Instance.Configuration.TitlePreference, preferredMetadataLanguage)?.Name;
         if (!string.IsNullOrEmpty(title))
         {
             episode.Name = Plugin.Instance.Configuration.AniDbReplaceGraves

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
@@ -94,8 +94,8 @@ public class AniDbEpisodeProvider(IServerConfigurationManager configurationManag
 
         var item = metadataResult.Item;
 
-        return new[]
-        {
+        return
+        [
             new RemoteSearchResult
             {
                 IndexNumber = item.IndexNumber,
@@ -107,7 +107,7 @@ public class AniDbEpisodeProvider(IServerConfigurationManager configurationManag
                 SearchProviderName = Name,
                 IndexNumberEnd = item.IndexNumberEnd
             }
-        };
+        ];
     }
 
     /// <inheritdoc />
@@ -157,7 +157,7 @@ public class AniDbEpisodeProvider(IServerConfigurationManager configurationManag
                         var length = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
                         if (!string.IsNullOrEmpty(length))
                         {
-                            if (long.TryParse(length, out var duration))
+                            if (long.TryParse(length, CultureInfo.InvariantCulture, out var duration))
                             {
                                 episode.RunTimeTicks = TimeSpan.FromMinutes(duration).Ticks;
                             }
@@ -169,7 +169,7 @@ public class AniDbEpisodeProvider(IServerConfigurationManager configurationManag
                         var airdate = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
                         if (!string.IsNullOrEmpty(airdate))
                         {
-                            if (DateTime.TryParse(airdate, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var date))
+                            if (DateTime.TryParse(airdate, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var date))
                             {
                                 episode.PremiereDate = date;
                             }

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
@@ -138,7 +138,7 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
     /// <returns>The special's document, or <c>null</c> when it cannot be identified.</returns>
     private async Task<FileInfo?> FindSpecialXml(EpisodeInfo info, string seriesId, CancellationToken cancellationToken)
     {
-        // The mapping sources are where a film that the season numbering files among the
+        // The mapping sources are where a movie that the season numbering files among the
         // specials is recorded. Nothing about AniDB's own specials can turn one up: it is an
         // anime of its own there, with ordinary episodes.
         if (info.IndexNumber is { } specialNumber)
@@ -216,7 +216,7 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
 
         // Position is the one route that reads nothing about the episode itself, so it only
         // holds where the library and AniDB agree on what the specials are. A library whose
-        // specials season also holds a film, a trailer or an episode AniDB files elsewhere
+        // specials season also holds a movie, a trailer or an episode AniDB files elsewhere
         // lines up with nothing, and numbering straight down the list would give every special
         // after the first difference the wrong entry.
         var libraryCount = AniDbSeasonLayout.Read(_libraryManager, seriesId)?.SpecialsCount;
@@ -567,7 +567,16 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
             ? string.Empty
             : string.Concat(value.Where(char.IsLetterOrDigit)).ToLowerInvariant();
 
-    private static async Task ParseEpisodeXml(FileInfo xml, Episode episode, string preferredMetadataLanguage)
+    /// <summary>
+    /// Fills an episode from its cached document. Internal because a movie AniDB holds inside
+    /// another entry is one of these episodes, and the movie provider reads its own name and
+    /// air date from here rather than from the whole entry's record.
+    /// </summary>
+    /// <param name="xml">The episode's cached document.</param>
+    /// <param name="episode">The episode to fill.</param>
+    /// <param name="preferredMetadataLanguage">The language its title is wanted in.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    internal static async Task ParseEpisodeXml(FileInfo xml, Episode episode, string preferredMetadataLanguage)
     {
         var settings = new XmlReaderSettings
         {
@@ -664,7 +673,14 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
         }
     }
 
-    private static FileInfo? GetEpisodeXmlFile(int? episodeNumber, string type, string seriesDataPath)
+    /// <summary>
+    /// The cached document of one episode of an entry.
+    /// </summary>
+    /// <param name="episodeNumber">The episode's number within the entry.</param>
+    /// <param name="type">The prefix of its numbering, from <see cref="AniDbEpisodeKindExtensions.Prefix"/>.</param>
+    /// <param name="seriesDataPath">Where the entry's documents are cached.</param>
+    /// <returns>The document, which may not exist, or <c>null</c> where no number was given.</returns>
+    internal static FileInfo? GetEpisodeXmlFile(int? episodeNumber, string type, string seriesDataPath)
     {
         if (episodeNumber == null)
         {

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
@@ -4,13 +4,17 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Providers;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 
@@ -21,9 +25,13 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 /// Creates a new instance of the <see cref="AniDbEpisodeProvider" /> class.
 /// </remarks>
 /// <param name="configurationManager">The configuration manager.</param>
-public class AniDbEpisodeProvider(IServerConfigurationManager configurationManager) : IRemoteMetadataProvider<Episode, EpisodeInfo>
+/// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+/// <param name="logger">Instance of the <see cref="ILogger{AniDbEpisodeProvider}"/> interface.</param>
+public partial class AniDbEpisodeProvider(IServerConfigurationManager configurationManager, ILibraryManager libraryManager, ILogger<AniDbEpisodeProvider> logger) : IRemoteMetadataProvider<Episode, EpisodeInfo>
 {
     private readonly IServerConfigurationManager _configurationManager = configurationManager;
+    private readonly ILibraryManager _libraryManager = libraryManager;
+    private readonly ILogger<AniDbEpisodeProvider> _logger = logger;
 
     /// <inheritdoc />
     public string Name => "AniDB";
@@ -34,31 +42,32 @@ public class AniDbEpisodeProvider(IServerConfigurationManager configurationManag
         cancellationToken.ThrowIfCancellationRequested();
         var result = new MetadataResult<Episode>();
 
-        var animeId = info.SeriesProviderIds.GetValueOrDefault(ProviderNames.AniDb);
-        if (string.IsNullOrEmpty(animeId))
+        var seriesId = info.SeriesProviderIds.GetValueOrDefault(ProviderNames.AniDb);
+        if (string.IsNullOrEmpty(seriesId))
         {
             return result;
         }
 
-        var seriesFolder = await FindSeriesFolder(animeId, cancellationToken).ConfigureAwait(false);
-        if (string.IsNullOrEmpty(seriesFolder))
+        FileInfo? xml;
+
+        try
         {
+            xml = info.ParentIndexNumber == 0
+                ? await FindSpecialXml(info, seriesId, cancellationToken).ConfigureAwait(false)
+                : await FindEpisodeXml(info, seriesId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (AniDbBannedException ex)
+        {
+            _logger.LogWarning(
+                "Season {SeasonNumber} episode {EpisodeNumber} of AniDB series {SeriesId} could not be looked up because AniDB has banned this client. It stays without metadata until the ban lapses, in {RetryAfter}",
+                info.ParentIndexNumber,
+                info.IndexNumber,
+                seriesId,
+                ex.RetryAfter);
+
             return result;
         }
 
-        if (!Plugin.Instance.Configuration.IgnoreSeason && info.ParentIndexNumber > 1)
-        {
-            return result;
-        }
-
-        string episodeType = string.Empty;
-
-        if (info.ParentIndexNumber == 0)
-        {
-            episodeType = "S";
-        }
-
-        var xml = GetEpisodeXmlFile(info.IndexNumber, episodeType, seriesFolder);
         if (xml == null || !xml.Exists)
         {
             return result;
@@ -67,7 +76,7 @@ public class AniDbEpisodeProvider(IServerConfigurationManager configurationManag
         result.Item = new Episode
         {
             IndexNumber = info.IndexNumber,
-            ParentIndexNumber = info.ParentIndexNumber ?? 1
+            ParentIndexNumber = info.ParentIndexNumber
         };
 
         result.HasMetadata = true;
@@ -75,6 +84,247 @@ public class AniDbEpisodeProvider(IServerConfigurationManager configurationManag
         await ParseEpisodeXml(xml, result.Item, info.MetadataLanguage).ConfigureAwait(false);
 
         return result;
+    }
+
+    private async Task<FileInfo?> FindEpisodeXml(EpisodeInfo info, string seriesId, CancellationToken cancellationToken)
+    {
+        var (animeId, numberInEntry, kind) = await GetEpisodeSource(info, seriesId, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(animeId) || numberInEntry is null)
+        {
+            return null;
+        }
+
+        var seriesFolder = await FindSeriesFolder(animeId, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(seriesFolder))
+        {
+            return null;
+        }
+
+        var xml = GetEpisodeXmlFile(numberInEntry, kind.Prefix(), seriesFolder);
+
+        if (xml == null || !xml.Exists)
+        {
+            _logger.LogWarning(
+                "Season {SeasonNumber} episode {EpisodeNumber} of AniDB series {SeriesId} has no counterpart in anime {AnimeId}, where it would be episode {EpisodeNumberInEntry}, and stays without metadata",
+                info.ParentIndexNumber,
+                info.IndexNumber,
+                seriesId,
+                animeId,
+                numberInEntry);
+
+            return null;
+        }
+
+        _logger.LogDebug(
+            "Season {SeasonNumber} episode {EpisodeNumber} of AniDB series {SeriesId} read from episode {EpisodeNumberInEntry} of anime {AnimeId}",
+            info.ParentIndexNumber,
+            info.IndexNumber,
+            seriesId,
+            numberInEntry,
+            animeId);
+
+        return xml;
+    }
+
+    /// <summary>
+    /// Finds the cached document of a special. Jellyfin gathers a show's specials into one
+    /// season and numbers them straight through, while AniDB keeps each season's specials in
+    /// that season's own entry, numbered from S1. The number alone would therefore read season
+    /// 1's S1 for season 2's S1, so the whole chain of entries is searched instead.
+    /// </summary>
+    /// <param name="info">The episode lookup info.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The special's document, or <c>null</c> when it cannot be identified.</returns>
+    private async Task<FileInfo?> FindSpecialXml(EpisodeInfo info, string seriesId, CancellationToken cancellationToken)
+    {
+        // The mapping sources are where a film that the season numbering files among the
+        // specials is recorded. Nothing about AniDB's own specials can turn one up: it is an
+        // anime of its own there, with ordinary episodes.
+        if (info.IndexNumber is { } specialNumber)
+        {
+            var placements = await AniDbMappings.ResolveSpecials(
+                _configurationManager.ApplicationPaths,
+                seriesId,
+                specialNumber,
+                _logger,
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var placed in placements)
+            {
+                var placedFolder = await FindSeriesFolder(placed.AnimeId, cancellationToken).ConfigureAwait(false);
+                var placedXml = string.IsNullOrEmpty(placedFolder)
+                    ? null
+                    : GetEpisodeXmlFile(placed.Number, placed.Kind.Prefix(), placedFolder);
+
+                if (placedXml?.Exists == true)
+                {
+                    _logger.LogDebug(
+                        "Special {EpisodeNumber} of AniDB series {SeriesId} read from {EpisodeNumberInEntry} of anime {AnimeId}, where the mapping sources place it",
+                        info.IndexNumber,
+                        seriesId,
+                        placed.Number,
+                        placed.AnimeId);
+
+                    return placedXml;
+                }
+            }
+
+            // A placement naming an episode that does not exist is not the end of the search.
+            // It means the source is wrong about this special, or the entry it names has not
+            // been fetched yet, and either way the show's own specials are still worth reading:
+            // that is how every special the sources do not place is identified.
+            if (placements.Count > 0)
+            {
+                _logger.LogDebug(
+                    "The mapping sources place special {EpisodeNumber} of AniDB series {SeriesId} at {Placement}, none of which holds such an episode, so it is matched against the show's own specials instead",
+                    info.IndexNumber,
+                    seriesId,
+                    string.Join(
+                        ", ",
+                        placements.Select(placed => FormattableString.Invariant($"{placed.Number} of anime {placed.AnimeId}"))));
+            }
+        }
+
+        var chain = await AniDbSeasonResolver.GetCachedSeasonChain(_configurationManager.ApplicationPaths, seriesId, cancellationToken).ConfigureAwait(false);
+
+        // Make sure the one entry a single-entry chain has is on disk. The rest of the chain is
+        // whatever was cached, which is all a special can be matched against without spending
+        // a request on every entry of the show.
+        if (chain.Count == 1)
+        {
+            var seriesFolder = await FindSeriesFolder(seriesId, cancellationToken).ConfigureAwait(false);
+
+            if (string.IsNullOrEmpty(seriesFolder))
+            {
+                return null;
+            }
+        }
+
+        var specials = await LoadSpecials(chain, cancellationToken).ConfigureAwait(false);
+
+        if (specials.Count == 0)
+        {
+            _logger.LogWarning(
+                "None of the {EntryCount} AniDB entries of series {SeriesId} has any special, so special {EpisodeNumber} stays without metadata",
+                chain.Count,
+                seriesId,
+                info.IndexNumber);
+
+            return null;
+        }
+
+        // Position is the one route that reads nothing about the episode itself, so it only
+        // holds where the library and AniDB agree on what the specials are. A library whose
+        // specials season also holds a film, a trailer or an episode AniDB files elsewhere
+        // lines up with nothing, and numbering straight down the list would give every special
+        // after the first difference the wrong entry.
+        var libraryCount = AniDbSeasonLayout.Read(_libraryManager, seriesId)?.SpecialsCount;
+        var aligned = Align(specials, libraryCount);
+
+        var match = MatchById(specials, info)
+            ?? MatchByTitle(specials, info)
+            ?? MatchByDate(specials, info)
+            ?? (aligned == null ? null : MatchByPosition(aligned, info));
+
+        if (match == null)
+        {
+            _logger.LogWarning(
+                "Special {EpisodeNumber} of AniDB series {SeriesId} matches none of the {SpecialCount} specials across its {EntryCount} AniDB entries by id, title or air date, so it stays without metadata. The library has {LibraryCount} specials, which line up with neither the whole of that list nor any single entry of it, so they cannot be numbered straight through. Set its AniDB id by hand to fill it in",
+                info.IndexNumber,
+                seriesId,
+                specials.Count,
+                chain.Count,
+                libraryCount);
+
+            return null;
+        }
+
+        _logger.LogDebug(
+            "Special {EpisodeNumber} of AniDB series {SeriesId} read from {EpisodeNumberInEntry} of anime {AnimeId}",
+            info.IndexNumber,
+            seriesId,
+            match.Number,
+            match.AnimeId);
+
+        return new FileInfo(match.Path);
+    }
+
+    /// <summary>
+    /// The specials the library's specials season can be numbered straight through, or
+    /// <c>null</c> where nothing lines up with it.
+    /// </summary>
+    /// <remarks>
+    /// The whole chain lines up where the library holds every special every entry of the show
+    /// lists. Where it does not, one entry's own specials still may: a show whose later seasons'
+    /// specials were never released, or never kept, holds exactly the specials of the entry they
+    /// belong to, and AniDB numbering them S1 upwards is the same order the library numbers them
+    /// in. Only one entry may hold that many for this to be evidence rather than a guess.
+    /// </remarks>
+    /// <param name="specials">Every special across the show's entries, in order.</param>
+    /// <param name="libraryCount">How many specials the library holds, or <c>null</c> where it cannot be read.</param>
+    /// <returns>The specials to count through, or <c>null</c>.</returns>
+    private static IReadOnlyList<AniDbSpecial>? Align(IReadOnlyList<AniDbSpecial> specials, int? libraryCount)
+    {
+        if (libraryCount is not > 0)
+        {
+            return null;
+        }
+
+        if (libraryCount == specials.Count)
+        {
+            return specials;
+        }
+
+        var entries = specials
+            .GroupBy(special => special.AnimeId, StringComparer.Ordinal)
+            .Where(entry => entry.Count() == libraryCount)
+            .ToList();
+
+        return entries.Count == 1 ? [.. entries[0].OrderBy(special => special.Number)] : null;
+    }
+
+    /// <summary>
+    /// Reads every special held by the given AniDB entries, in season order and, within an
+    /// entry, in AniDB's own numbering.
+    /// </summary>
+    /// <param name="chain">The AniDB entries the series spans, in season order.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The specials.</returns>
+    private async Task<IReadOnlyList<AniDbSpecial>> LoadSpecials(IReadOnlyList<string> chain, CancellationToken cancellationToken)
+    {
+        var specials = new List<AniDbSpecial>();
+
+        foreach (var animeId in chain)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // The cached path, not GetSeriesData: this runs once per special, and a stale
+            // entry must not turn a local lookup into a download.
+            var folder = AniDbSeriesProvider.GetSeriesDataPath(_configurationManager.ApplicationPaths, animeId);
+            if (!Directory.Exists(folder))
+            {
+                continue;
+            }
+
+            var inEntry = new List<AniDbSpecial>();
+
+            foreach (var path in Directory.EnumerateFiles(folder, "episode-S*.xml"))
+            {
+                var number = SpecialNumberRegex().Match(Path.GetFileName(path));
+                if (!number.Success || !int.TryParse(number.Groups[1].ValueSpan, CultureInfo.InvariantCulture, out var index))
+                {
+                    continue;
+                }
+
+                inEntry.Add(await ParseSpecial(path, animeId, index).ConfigureAwait(false));
+            }
+
+            // Directory order is the file system's. AniDB's numbering is the real order.
+            specials.AddRange(inEntry.OrderBy(special => special.Number));
+        }
+
+        return specials;
     }
 
     /// <inheritdoc />
@@ -117,11 +367,205 @@ public class AniDbEpisodeProvider(IServerConfigurationManager configurationManag
         return imageProvider.GetImageResponse(url, cancellationToken);
     }
 
+    /// <summary>
+    /// Finds the AniDB entry an episode is read from, and its number within that entry. The two
+    /// numbers differ when the season it is shown under is split across several AniDB entries.
+    /// </summary>
+    /// <param name="info">The episode lookup info.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The entry and the episode's number in it, or nulls when neither can be identified.</returns>
+    private async Task<(string? AnimeId, int? NumberInEntry, AniDbEpisodeKind Kind)> GetEpisodeSource(EpisodeInfo info, string seriesId, CancellationToken cancellationToken)
+    {
+        if (info.IndexNumber is not { } episodeNumber)
+        {
+            return (null, null, AniDbEpisodeKind.Regular);
+        }
+
+        // Every AniDB anime numbers its episodes from one, so an episode can only be looked up
+        // against the entry holding its own season. Specials are the exception: AniDB keeps
+        // them in the entry they belong to, under their own numbering.
+        if (Plugin.Instance.Configuration.IgnoreSeason || info.ParentIndexNumber is null or <= 0)
+        {
+            return (seriesId, episodeNumber, AniDbEpisodeKind.Regular);
+        }
+
+        var segments = await AniDbSeasonResolver.ResolveSeasonSegments(
+            _configurationManager.ApplicationPaths,
+            _libraryManager,
+            seriesId,
+            info.ParentIndexNumber.Value,
+            _logger,
+            cancellationToken).ConfigureAwait(false);
+
+        // The season provider stores the entry a season starts in, so an id that is not that
+        // one was set by hand in the metadata editor. That names the entry to read, and its
+        // episodes are numbered from one there.
+        var seasonId = info.SeasonProviderIds.GetValueOrDefault(ProviderNames.AniDb);
+        if (!string.IsNullOrEmpty(seasonId)
+            && (segments == null || !string.Equals(seasonId, segments[0].AnimeId, StringComparison.Ordinal)))
+        {
+            return (seasonId, episodeNumber, AniDbEpisodeKind.Regular);
+        }
+
+        if (segments == null)
+        {
+            return (null, null, AniDbEpisodeKind.Regular);
+        }
+
+        var segment = AniDbSeasonResolver.PickSegment(segments, episodeNumber);
+
+        return (segment.AnimeId, segment.FirstEpisodeInEntry + (episodeNumber - segment.FirstEpisodeNumber), segment.Kind);
+    }
+
     private async Task<string?> FindSeriesFolder(string seriesId, CancellationToken cancellationToken)
     {
         var seriesDataPath = await AniDbSeriesProvider.GetSeriesData(_configurationManager.ApplicationPaths, seriesId, cancellationToken).ConfigureAwait(false);
         return Path.GetDirectoryName(seriesDataPath);
     }
+
+    private static async Task<AniDbSpecial> ParseSpecial(string path, string animeId, int number)
+    {
+        var settings = new XmlReaderSettings
+        {
+            Async = true,
+            CheckCharacters = false,
+            IgnoreProcessingInstructions = true,
+            IgnoreComments = true,
+            ValidationType = ValidationType.None
+        };
+
+        string? episodeId = null;
+        DateTime? airDate = null;
+        var titles = new List<string>();
+
+        using (var streamReader = new StreamReader(path))
+        using (var reader = XmlReader.Create(streamReader, settings))
+        {
+            await reader.MoveToContentAsync().ConfigureAwait(false);
+
+            episodeId = reader.GetAttribute("id");
+
+            while (await reader.ReadAsync().ConfigureAwait(false))
+            {
+                if (reader.NodeType != XmlNodeType.Element)
+                {
+                    continue;
+                }
+
+                switch (reader.Name)
+                {
+                    case "airdate":
+                        var value = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
+
+                        if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
+                        {
+                            airDate = parsed;
+                        }
+
+                        break;
+
+                    case "title":
+                        var title = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
+
+                        if (!string.IsNullOrWhiteSpace(title))
+                        {
+                            titles.Add(title);
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        return new AniDbSpecial(animeId, path, number, episodeId, airDate, titles);
+    }
+
+    /// <summary>
+    /// Matches the special whose AniDB id the item already carries. Set by hand in the
+    /// metadata editor, so it is the one signal that cannot be wrong.
+    /// </summary>
+    /// <param name="specials">The specials to match against.</param>
+    /// <param name="info">The episode lookup info.</param>
+    /// <returns>The matching special, or <c>null</c>.</returns>
+    private static AniDbSpecial? MatchById(IReadOnlyList<AniDbSpecial> specials, EpisodeInfo info)
+    {
+        var episodeId = info.ProviderIds.GetValueOrDefault(ProviderNames.AniDb);
+
+        return string.IsNullOrEmpty(episodeId)
+            ? null
+            : specials.FirstOrDefault(special => string.Equals(special.EpisodeId, episodeId, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Matches on the name the file was scanned under. Only an unambiguous hit counts, since
+    /// two seasons of the same show routinely name their specials alike.
+    /// </summary>
+    /// <param name="specials">The specials to match against.</param>
+    /// <param name="info">The episode lookup info.</param>
+    /// <returns>The matching special, or <c>null</c>.</returns>
+    private static AniDbSpecial? MatchByTitle(IReadOnlyList<AniDbSpecial> specials, EpisodeInfo info)
+    {
+        var name = Normalize(info.Name);
+
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        var matches = specials
+            .Where(special => special.Titles.Any(title => string.Equals(Normalize(title), name, StringComparison.Ordinal)))
+            .ToList();
+
+        return matches.Count == 1 ? matches[0] : null;
+    }
+
+    /// <summary>
+    /// Matches on the air date another provider has already filled in. Only an unambiguous
+    /// hit counts.
+    /// </summary>
+    /// <param name="specials">The specials to match against.</param>
+    /// <param name="info">The episode lookup info.</param>
+    /// <returns>The matching special, or <c>null</c>.</returns>
+    private static AniDbSpecial? MatchByDate(IReadOnlyList<AniDbSpecial> specials, EpisodeInfo info)
+    {
+        if (info.PremiereDate is not { } premiereDate)
+        {
+            return null;
+        }
+
+        var matches = specials
+            .Where(special => special.AirDate?.Date == premiereDate.Date)
+            .ToList();
+
+        return matches.Count == 1 ? matches[0] : null;
+    }
+
+    /// <summary>
+    /// Falls back to where the special sits in the season. Jellyfin numbers specials straight
+    /// through in season order, which is the order they are gathered in here, so the numbers
+    /// line up as long as the library holds every special the entries list.
+    /// </summary>
+    /// <param name="specials">The specials to match against.</param>
+    /// <param name="info">The episode lookup info.</param>
+    /// <returns>The matching special, or <c>null</c>.</returns>
+    private static AniDbSpecial? MatchByPosition(IReadOnlyList<AniDbSpecial> specials, EpisodeInfo info)
+    {
+        var position = info.IndexNumber - 1;
+
+        return position >= 0 && position < specials.Count ? specials[position.Value] : null;
+    }
+
+    /// <summary>
+    /// Reduces a title to its letters and digits, so that punctuation, spacing and case
+    /// cannot keep two spellings of the same name apart.
+    /// </summary>
+    /// <param name="value">The title to reduce.</param>
+    /// <returns>The reduced title.</returns>
+    private static string Normalize(string? value)
+        => string.IsNullOrWhiteSpace(value)
+            ? string.Empty
+            : string.Concat(value.Where(char.IsLetterOrDigit)).ToLowerInvariant();
 
     private static async Task ParseEpisodeXml(FileInfo xml, Episode episode, string preferredMetadataLanguage)
     {
@@ -230,4 +674,24 @@ public class AniDbEpisodeProvider(IServerConfigurationManager configurationManag
         var filename = Path.Combine(seriesDataPath, FormattableString.Invariant($"episode-{(type ?? string.Empty) + episodeNumber.Value}.xml"));
         return new FileInfo(filename);
     }
+
+    [GeneratedRegex(@"^episode-S(\d+)\.xml$")]
+    private static partial Regex SpecialNumberRegex();
+
+    /// <summary>
+    /// A special held by one AniDB entry.
+    /// </summary>
+    /// <param name="AnimeId">The AniDB id of the entry holding it.</param>
+    /// <param name="Path">The path of its cached document.</param>
+    /// <param name="Number">Its number within that entry.</param>
+    /// <param name="EpisodeId">Its own AniDB episode id.</param>
+    /// <param name="AirDate">The date it aired.</param>
+    /// <param name="Titles">Every title AniDB records for it.</param>
+    private sealed record AniDbSpecial(
+        string AnimeId,
+        string Path,
+        int Number,
+        string? EpisodeId,
+        DateTime? AirDate,
+        IReadOnlyList<string> Titles);
 }

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbImageProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbImageProvider.cs
@@ -73,7 +73,7 @@ public class AniDbImageProvider(IApplicationPaths appPaths) : IRemoteImageProvid
     /// <inheritdoc />
     public IEnumerable<ImageType> GetSupportedImages(BaseItem item)
     {
-        return new[] { ImageType.Primary };
+        return [ImageType.Primary];
     }
 
     /// <inheritdoc />

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbLibrarySeason.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbLibrarySeason.cs
@@ -1,0 +1,9 @@
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+/// <summary>
+/// A season as the library holds it, described by the episode numbers it actually spans.
+/// </summary>
+/// <param name="Number">The Jellyfin season number.</param>
+/// <param name="FirstEpisodeNumber">The lowest episode number in the season, which is 1 unless the files are numbered straight through the show.</param>
+/// <param name="EpisodeCount">How many episode numbers the season spans, counting the gaps left by episodes the library does not have.</param>
+internal sealed record AniDbLibrarySeason(int Number, int FirstEpisodeNumber, int EpisodeCount);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbMovieProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbMovieProvider.cs
@@ -53,6 +53,7 @@ public class AniDbMovieProvider(IApplicationPaths appPaths) : IRemoteMetadataPro
                         CommunityRating = seriesResult.Item.CommunityRating,
                         Studios = seriesResult.Item.Studios,
                         Genres = seriesResult.Item.Genres,
+                        Tags = seriesResult.Item.Tags,
                         ProviderIds = seriesResult.Item.ProviderIds
                     },
                     People = seriesResult.People,

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbMovieProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbMovieProvider.cs
@@ -1,11 +1,17 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 
@@ -13,9 +19,11 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 /// The AniDB metadata provider for movies.
 /// </summary>
 /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
-public class AniDbMovieProvider(IApplicationPaths appPaths) : IRemoteMetadataProvider<Movie, MovieInfo>
+/// <param name="logger">Instance of the <see cref="ILogger{AniDbMovieProvider}"/> interface.</param>
+public class AniDbMovieProvider(IApplicationPaths appPaths, ILogger<AniDbMovieProvider>? logger = null) : IRemoteMetadataProvider<Movie, MovieInfo>
 {
     private readonly AniDbSeriesProvider _seriesProvider = new AniDbSeriesProvider(appPaths);
+    private readonly ILogger _logger = logger ?? (ILogger)NullLogger.Instance;
 
     /// <inheritdoc />
     public string Name => "AniDB";
@@ -24,6 +32,35 @@ public class AniDbMovieProvider(IApplicationPaths appPaths) : IRemoteMetadataPro
     public async Task<MetadataResult<Movie>> GetMetadata(MovieInfo info, CancellationToken cancellationToken)
     {
         var animeId = info.ProviderIds.GetValueOrDefault(ProviderNames.AniDb);
+        MappedMovie? mapped = null;
+
+        // An id another provider has already settled on names the movie outright, where the name
+        // is the weaker evidence: AniDB spells a great many titles differently, and a movie shares
+        // its title with the series it was made from as often as not.
+        if (string.IsNullOrEmpty(animeId))
+        {
+            mapped = await AniDbMappings.ResolveMovieId(
+                appPaths,
+                info.ProviderIds.GetValueOrDefault(nameof(MetadataProvider.Tmdb)),
+                info.ProviderIds.GetValueOrDefault(nameof(MetadataProvider.Imdb)),
+                info.ProviderIds.GetValueOrDefault(nameof(MetadataProvider.Tvdb)),
+                _logger,
+                cancellationToken).ConfigureAwait(false);
+
+            if (mapped != null)
+            {
+                animeId = mapped.Episode.AnimeId;
+
+                _logger.LogInformation(
+                    "{MovieName} is {EpisodeNumberInEntry} of AniDB anime {AnimeId}, which {Source} file under {Provider} {ProviderId}",
+                    info.Name,
+                    mapped.Episode.Kind.Prefix() + mapped.Episode.Number,
+                    mapped.Episode.AnimeId,
+                    mapped.Source,
+                    mapped.Provider,
+                    mapped.ProviderId);
+            }
+        }
 
         var seriesInfo = new SeriesInfo();
         seriesInfo.ProviderIds.Add(ProviderNames.AniDb, animeId);
@@ -39,23 +76,30 @@ public class AniDbMovieProvider(IApplicationPaths appPaths) : IRemoteMetadataPro
 
             if (seriesResult.HasMetadata)
             {
+                var movie = new Movie
+                {
+                    Name = seriesResult.Item.Name,
+                    OriginalTitle = seriesResult.Item.OriginalTitle,
+                    Overview = seriesResult.Item.Overview,
+                    PremiereDate = seriesResult.Item.PremiereDate,
+                    ProductionYear = seriesResult.Item.ProductionYear,
+                    EndDate = seriesResult.Item.EndDate,
+                    CommunityRating = seriesResult.Item.CommunityRating,
+                    Studios = seriesResult.Item.Studios,
+                    Genres = seriesResult.Item.Genres,
+                    Tags = seriesResult.Item.Tags,
+                    ProviderIds = seriesResult.Item.ProviderIds
+                };
+
+                if (mapped != null)
+                {
+                    await ReadFromEpisode(movie, mapped, info.MetadataLanguage).ConfigureAwait(false);
+                }
+
                 return new MetadataResult<Movie>
                 {
                     HasMetadata = true,
-                    Item = new Movie
-                    {
-                        Name = seriesResult.Item.Name,
-                        OriginalTitle = seriesResult.Item.OriginalTitle,
-                        Overview = seriesResult.Item.Overview,
-                        PremiereDate = seriesResult.Item.PremiereDate,
-                        ProductionYear = seriesResult.Item.ProductionYear,
-                        EndDate = seriesResult.Item.EndDate,
-                        CommunityRating = seriesResult.Item.CommunityRating,
-                        Studios = seriesResult.Item.Studios,
-                        Genres = seriesResult.Item.Genres,
-                        Tags = seriesResult.Item.Tags,
-                        ProviderIds = seriesResult.Item.ProviderIds
-                    },
+                    Item = movie,
                     People = seriesResult.People,
                     Images = seriesResult.Images
                 };
@@ -85,5 +129,83 @@ public class AniDbMovieProvider(IApplicationPaths appPaths) : IRemoteMetadataPro
     public Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
     {
         return _seriesProvider.GetImageResponse(url, cancellationToken);
+    }
+
+    /// <summary>
+    /// Takes what an entry records about the one episode a movie is, over what it records about
+    /// itself.
+    /// </summary>
+    /// <remarks>
+    /// A movie AniDB registered in its own right is its entry's first ordinary episode, and the
+    /// entry's own record is already the movie's: there is nothing to take. The rest - a movie
+    /// AniDB holds among another entry's other episodes or specials, which is how it holds
+    /// Berserk's Memorial Edition and the theatrical cuts of several television series - would
+    /// otherwise be given the name, date and running time of whatever it was released
+    /// alongside, and a library holding several such movies of one show would show them as
+    /// several copies of the same thing.
+    /// <para>
+    /// The cast, studios, genres and rating are left as the entry's. They belong to the
+    /// production rather than to the episode, and AniDB records none of them per episode.
+    /// </para>
+    /// </remarks>
+    /// <param name="movie">The movie, already filled from its entry.</param>
+    /// <param name="mapped">What identified it, and which episode of the entry it is.</param>
+    /// <param name="preferredMetadataLanguage">The language its title is wanted in.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    private async Task ReadFromEpisode(Movie movie, MappedMovie mapped, string preferredMetadataLanguage)
+    {
+        if (mapped.Episode.Kind == AniDbEpisodeKind.Regular && mapped.Episode.Number <= 1)
+        {
+            return;
+        }
+
+        var folder = AniDbSeriesProvider.GetSeriesDataPath(appPaths, mapped.Episode.AnimeId);
+        var xml = AniDbEpisodeProvider.GetEpisodeXmlFile(mapped.Episode.Number, mapped.Episode.Kind.Prefix(), folder);
+
+        if (xml?.Exists != true)
+        {
+            _logger.LogWarning(
+                "{MovieName} is {EpisodeNumberInEntry} of AniDB anime {AnimeId}, where {Source} place it, but that entry records no such episode, so the movie is described by the entry as a whole",
+                movie.Name,
+                mapped.Episode.Kind.Prefix() + mapped.Episode.Number,
+                mapped.Episode.AnimeId,
+                mapped.Source);
+
+            return;
+        }
+
+        // Read into an episode of its own and copied across, rather than parsed straight onto
+        // the movie: the reader fills in what the document holds and says nothing about the rest,
+        // and an episode with no summary of its own must not empty the movie's.
+        var episode = new Episode();
+
+        await AniDbEpisodeProvider.ParseEpisodeXml(xml, episode, preferredMetadataLanguage).ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(episode.Name))
+        {
+            movie.Name = episode.Name;
+        }
+
+        if (!string.IsNullOrEmpty(episode.Overview))
+        {
+            movie.Overview = episode.Overview;
+        }
+
+        if (episode.PremiereDate != null)
+        {
+            movie.PremiereDate = episode.PremiereDate;
+            movie.ProductionYear = episode.PremiereDate.Value.Year;
+        }
+
+        if (episode.RunTimeTicks is > 0)
+        {
+            movie.RunTimeTicks = episode.RunTimeTicks;
+        }
+
+        _logger.LogDebug(
+            "{MovieName} is named and dated from {EpisodeNumberInEntry} of AniDB anime {AnimeId} rather than from the entry as a whole",
+            movie.Name,
+            mapped.Episode.Kind.Prefix() + mapped.Episode.Number,
+            mapped.Episode.AnimeId);
     }
 }

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbMovieProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbMovieProvider.cs
@@ -30,7 +30,7 @@ public class AniDbMovieProvider(IApplicationPaths appPaths) : IRemoteMetadataPro
 
         if (string.IsNullOrEmpty(animeId) && !string.IsNullOrEmpty(info.Name))
         {
-            animeId = await Equals_check.XmlFindId(info.Name, cancellationToken).ConfigureAwait(false);
+            animeId = await Equals_check.XmlFindId(info.Name, info.Year ?? info.PremiereDate?.Year, cancellationToken).ConfigureAwait(false);
         }
 
         if (!string.IsNullOrEmpty(animeId))

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonLayout.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonLayout.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+/// <summary>
+/// How a series is laid out in the library: which seasons it has, and which episode numbers
+/// each of them spans. AniDB has no seasons of its own, so this is what its entries are
+/// mapped onto.
+/// </summary>
+internal sealed class AniDbSeasonLayout
+{
+    /// <summary>
+    /// The library id of each series already looked up by AniDB id, so that a scan does not
+    /// search the whole library again for every episode it refreshes.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, Guid> _seriesIds = new(StringComparer.Ordinal);
+
+    private AniDbSeasonLayout(IReadOnlyList<AniDbLibrarySeason> seasons, int specialsCount, string signature)
+    {
+        Seasons = seasons;
+        SpecialsCount = specialsCount;
+        Signature = signature;
+    }
+
+    /// <summary>
+    /// Gets the seasons the series has, in season order. Specials are left out: AniDB keeps
+    /// those inside the entry they belong to rather than in an entry of their own.
+    /// </summary>
+    public IReadOnlyList<AniDbLibrarySeason> Seasons { get; }
+
+    /// <summary>
+    /// Gets how many episodes the series has under season 0. AniDB keeps a season's specials in
+    /// that season's own entry, so this is what says whether the library holds the same set.
+    /// </summary>
+    public int SpecialsCount { get; }
+
+    /// <summary>
+    /// Gets a value that changes whenever the layout does, so that a mapping built from an
+    /// earlier one is not reused after episodes have been added or removed.
+    /// </summary>
+    public string Signature { get; }
+
+    /// <summary>
+    /// Reads the layout of the series with the given AniDB id.
+    /// </summary>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <returns>The layout, or <c>null</c> when the series or its episodes cannot be seen.</returns>
+    public static AniDbSeasonLayout? Read(ILibraryManager? libraryManager, string seriesId)
+    {
+        if (libraryManager == null || string.IsNullOrEmpty(seriesId))
+        {
+            return null;
+        }
+
+        var cached = _seriesIds.TryGetValue(seriesId, out var seriesItemId);
+
+        if (!cached)
+        {
+            seriesItemId = FindSeries(libraryManager, seriesId);
+
+            if (seriesItemId == Guid.Empty)
+            {
+                return null;
+            }
+
+            _seriesIds[seriesId] = seriesItemId;
+        }
+
+        var episodes = ReadEpisodes(libraryManager, seriesItemId);
+
+        // A library removed and added again gives the series a new id, which leaves the cached
+        // one pointing at nothing. Nothing else makes a series that was found have no episodes
+        // at all, so look it up once more before believing it.
+        if (episodes.Count == 0 && cached)
+        {
+            seriesItemId = FindSeries(libraryManager, seriesId);
+
+            if (seriesItemId == Guid.Empty)
+            {
+                _seriesIds.TryRemove(seriesId, out _);
+
+                return null;
+            }
+
+            _seriesIds[seriesId] = seriesItemId;
+            episodes = ReadEpisodes(libraryManager, seriesItemId);
+        }
+
+        var spans = new Dictionary<int, (int First, int Last)>();
+        var specials = 0;
+
+        foreach (var item in episodes)
+        {
+            if (item.ParentIndexNumber is not >= 0 || item.IndexNumber is not > 0)
+            {
+                continue;
+            }
+
+            if (item.ParentIndexNumber == 0)
+            {
+                specials++;
+
+                continue;
+            }
+
+            var season = item.ParentIndexNumber.Value;
+            var first = item.IndexNumber.Value;
+
+            // A file holding two episodes covers both numbers.
+            var last = Math.Max(first, (item as Episode)?.IndexNumberEnd ?? first);
+
+            spans[season] = spans.TryGetValue(season, out var span)
+                ? (Math.Min(span.First, first), Math.Max(span.Last, last))
+                : (first, last);
+        }
+
+        if (spans.Count == 0 && specials == 0)
+        {
+            return null;
+        }
+
+        var seasons = spans
+            .OrderBy(entry => entry.Key)
+            .Select(entry => new AniDbLibrarySeason(entry.Key, entry.Value.First, entry.Value.Last - entry.Value.First + 1))
+            .ToList();
+
+        var signature = string.Join(
+            ',',
+            seasons.Select(season => FormattableString.Invariant($"{season.Number}:{season.FirstEpisodeNumber}:{season.EpisodeCount}")))
+            + FormattableString.Invariant($";S{specials}");
+
+        return new AniDbSeasonLayout(seasons, specials, signature);
+    }
+
+    /// <summary>
+    /// Finds the library id of the series with the given AniDB id.
+    /// </summary>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <returns>The library id, or <see cref="Guid.Empty"/> when the library holds no such series.</returns>
+    private static Guid FindSeries(ILibraryManager libraryManager, string seriesId)
+    {
+        var matches = libraryManager.GetItemList(new InternalItemsQuery
+        {
+            IncludeItemTypes = [BaseItemKind.Series],
+            HasAnyProviderId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { ProviderNames.AniDb, seriesId } },
+            Recursive = true,
+            DtoOptions = new DtoOptions(false)
+        });
+
+        return matches.Count == 0 ? Guid.Empty : matches[0].Id;
+    }
+
+    /// <summary>
+    /// Reads every episode of the given series. Queried under the series rather than under each
+    /// season, so that the episodes of a season Jellyfin synthesised for a flat folder are still
+    /// found: on the refresh that creates such a season they have not been moved under it yet.
+    /// </summary>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    /// <param name="seriesItemId">The library id of the series.</param>
+    /// <returns>The episodes.</returns>
+    private static IReadOnlyList<BaseItem> ReadEpisodes(ILibraryManager libraryManager, Guid seriesItemId)
+        => libraryManager.GetItemList(new InternalItemsQuery
+        {
+            IncludeItemTypes = [BaseItemKind.Episode],
+            AncestorIds = [seriesItemId],
+            Recursive = true,
+            DtoOptions = new DtoOptions(false)
+        });
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonProvider.cs
@@ -4,10 +4,11 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Common.Configuration;
-using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Providers;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 
@@ -15,9 +16,13 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 /// The AniDB metadata provider for seasons.
 /// </summary>
 /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
-public class AniDbSeasonProvider(IApplicationPaths appPaths) : IRemoteMetadataProvider<Season, SeasonInfo>
+/// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+/// <param name="logger">Instance of the <see cref="ILogger{AniDbSeasonProvider}"/> interface.</param>
+public class AniDbSeasonProvider(IApplicationPaths appPaths, ILibraryManager libraryManager, ILogger<AniDbSeasonProvider> logger) : IRemoteMetadataProvider<Season, SeasonInfo>
 {
     private readonly AniDbSeriesProvider _seriesProvider = new AniDbSeriesProvider(appPaths);
+    private readonly ILibraryManager _libraryManager = libraryManager;
+    private readonly ILogger<AniDbSeasonProvider> _logger = logger;
 
     /// <inheritdoc />
     public string Name => "AniDB";
@@ -35,25 +40,85 @@ public class AniDbSeasonProvider(IApplicationPaths appPaths) : IRemoteMetadataPr
             }
         };
 
-        var seriesId = info.ProviderIds.GetValueOrDefault(ProviderNames.AniDb);
-        if (seriesId == null)
+        var seriesId = info.SeriesProviderIds.GetValueOrDefault(ProviderNames.AniDb);
+        var seasonId = info.ProviderIds.GetValueOrDefault(ProviderNames.AniDb);
+
+        // Whether the season is the whole of the entry it comes from, or a run of episodes part
+        // way into one. A long-running show is often a single AniDB entry that the season
+        // numbering breaks into several seasons, and those seasons share none of its dates.
+        var wholeEntry = true;
+
+        if (string.IsNullOrEmpty(seasonId) && !string.IsNullOrEmpty(seriesId))
+        {
+            try
+            {
+                var segment = await AniDbSeasonResolver.ResolveSeason(appPaths, _libraryManager, seriesId, info.IndexNumber, _logger, cancellationToken).ConfigureAwait(false);
+
+                seasonId = segment?.AnimeId;
+                wholeEntry = segment?.FirstEpisodeInEntry <= 1;
+            }
+            catch (AniDbBannedException ex)
+            {
+                _logger.LogWarning(
+                    "Season {SeasonNumber} of AniDB series {SeriesId} could not be identified because AniDB has banned this client. It stays without metadata until the ban lapses, in {RetryAfter}, and the next refresh after that will fill it in",
+                    info.IndexNumber,
+                    seriesId,
+                    ex.RetryAfter);
+
+                return result;
+            }
+        }
+
+        if (string.IsNullOrEmpty(seasonId))
         {
             return result;
         }
 
-        var seriesInfo = new SeriesInfo();
-        seriesInfo.ProviderIds.Add(ProviderNames.AniDb, seriesId);
+        _logger.LogDebug(
+            "Season {SeasonNumber} of AniDB series {SeriesId} filled from anime {SeasonId}",
+            info.IndexNumber,
+            seriesId,
+            seasonId);
+
+        // Recorded so the episode and image providers see the season's own entry instead of
+        // resolving it again.
+        result.Item.ProviderIds[ProviderNames.AniDb] = seasonId;
+
+        // Specials have no entry of their own, which is why the id above is the series'. The
+        // episodes need it, but the season must not be filled from it: the specials did not
+        // air on the series' dates, and are not named or rated as the series is. A season that
+        // is one run of episodes out of a longer entry is the same case.
+        if (info.IndexNumber <= 0 || !wholeEntry)
+        {
+            return result;
+        }
+
+        var seriesInfo = new SeriesInfo
+        {
+            MetadataLanguage = info.MetadataLanguage,
+            MetadataCountryCode = info.MetadataCountryCode
+        };
+
+        seriesInfo.ProviderIds.Add(ProviderNames.AniDb, seasonId);
 
         var seriesResult = await _seriesProvider.GetMetadata(seriesInfo, cancellationToken).ConfigureAwait(false);
         if (seriesResult.HasMetadata)
         {
-            result.Item.Name = seriesResult.Item.Name;
+            // The first season is the series entry, so taking its title would name the season
+            // after the show it sits under. A later season has a title of its own.
+            if (Plugin.Instance.Configuration.UseAniDbSeasonNames
+                && !string.Equals(seasonId, seriesId, StringComparison.Ordinal))
+            {
+                result.Item.Name = seriesResult.Item.Name;
+            }
+
             result.Item.Overview = seriesResult.Item.Overview;
             result.Item.PremiereDate = seriesResult.Item.PremiereDate;
             result.Item.EndDate = seriesResult.Item.EndDate;
             result.Item.CommunityRating = seriesResult.Item.CommunityRating;
             result.Item.Studios = seriesResult.Item.Studios;
             result.Item.Genres = seriesResult.Item.Genres;
+            result.Item.Tags = seriesResult.Item.Tags;
         }
 
         return result;

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonResolver.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonResolver.cs
@@ -1,0 +1,1513 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Identity;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+/// <summary>
+/// Maps a Jellyfin season to the AniDB anime that holds it.
+/// </summary>
+internal static partial class AniDbSeasonResolver
+{
+    /// <summary>
+    /// How many candidates one route may read. An uncached candidate costs an AniDB request,
+    /// so a long relation list cannot spend the whole allowance. The relation route and the
+    /// title route get this many each.
+    /// </summary>
+    private const int MaxCandidatesPerRoute = 4;
+
+    /// <summary>
+    /// How many AniDB entries one series is assumed to span. Bounds the relation walk done
+    /// for specials, which has no season number to stop at.
+    /// </summary>
+    private const int MaxSeasonsInChain = 12;
+
+    /// <summary>
+    /// How far back along prequel relations a name match is followed.
+    /// </summary>
+    private const int MaxPrequelHops = 4;
+
+    /// <summary>
+    /// How many episode numbers a season must still be short of before a second AniDB entry is
+    /// pulled into it. A season split across two entries is short by a whole cour, while a
+    /// season that merely counts an extra file is short by one, and must not swallow the entry
+    /// that belongs to the next season.
+    /// </summary>
+    private const int MinimumSplitEpisodes = 3;
+
+    /// <summary>
+    /// How many movies or OVAs in a row the walk will step over to reach the next season. Also
+    /// what stops a relation graph that leads back on itself from being followed forever.
+    /// </summary>
+    private const int MaxInterludeHops = 2;
+
+    /// <summary>
+    /// How many AniDB entries one season may be filled from. A season released in cours is two
+    /// entries, occasionally three; a higher count means the episode numbers the season spans
+    /// are not what they seem, and the later seasons must not be consumed on the strength of it.
+    /// </summary>
+    private const int MaxSegmentsPerSeason = 3;
+
+    /// <summary>
+    /// The AniDB formats a Jellyfin season may be. Sequel relations also point at OVAs,
+    /// movies and specials, which are separate items in Jellyfin.
+    /// </summary>
+    private static readonly string[] _seasonAnimeTypes = ["TV Series", "Web"];
+
+    /// <summary>
+    /// How far into a season the one that follows it may start. AniDB's end date is the last
+    /// episode's air date, which a delayed finale or a recap can push past the sequel's start.
+    /// </summary>
+    private static readonly TimeSpan _airingOverlapAllowance = TimeSpan.FromDays(31);
+
+    private static readonly string[] _romanNumerals = ["II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"];
+
+    /// <summary>
+    /// The AniDB entries each season of a series was mapped to, keyed by the series id and the
+    /// layout it was built from. Building one walks the chain of entries from the series, and
+    /// the season and episode providers ask for the same mapping. The layout is part of the key
+    /// so that adding episodes to the library rebuilds it rather than reusing an answer that
+    /// was right for fewer of them.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, IReadOnlyDictionary<int, IReadOnlyList<AniDbSeasonSegment>>> _mappings = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// One gate per mapping. A scan asks for the same series once per season and once per
+    /// episode, all at the same time; without this each of them would walk the chain, and every
+    /// walk costs AniDB requests that the first one is about to make anyway.
+    /// </summary>
+    /// <summary>
+    /// How many episodes AniDB records for an entry, against the timestamp of the document it
+    /// was read from. Checking a placement needs this for each of its segments, and each of a
+    /// season's episodes has the placement checked, so parsing that document every time would
+    /// cost more than the check is worth. Keyed by timestamp so that a document downloaded
+    /// again is read again: an entry still airing gains episodes.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, (DateTime WrittenAtUtc, int EpisodeCount)> _episodeCounts = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The seasons whose placement has already been reported, so that it is said once rather
+    /// than once per episode.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, byte> _reportedPlacements = new(StringComparer.Ordinal);
+
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> _mappingGates = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The seasons already reported as unmappable. Every episode of such a season asks about it
+    /// too, and one line per season is what says something the log does not already have.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, byte> _reportedUnmapped = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Finds the AniDB id of the anime holding the given season of the given series.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface, used to read how the series is laid out.</param>
+    /// <param name="seriesId">The AniDB id of the series, which is also its first season.</param>
+    /// <param name="seasonNumber">The Jellyfin season number.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The entry the season starts in, or <c>null</c> when it cannot be identified.</returns>
+    public static async Task<AniDbSeasonSegment?> ResolveSeason(
+        IApplicationPaths appPaths,
+        ILibraryManager? libraryManager,
+        string seriesId,
+        int? seasonNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        // The first season is the series entry itself, and so are specials: AniDB keeps
+        // them inside the entry they belong to.
+        if (Plugin.Instance.Configuration.IgnoreSeason || seasonNumber is null or <= 1)
+        {
+            return new AniDbSeasonSegment(seriesId, 1, 0);
+        }
+
+        var segments = await ResolveSeasonSegments(appPaths, libraryManager, seriesId, seasonNumber.Value, logger, cancellationToken).ConfigureAwait(false);
+
+        // The season is filled from the entry it starts in. A season split across two entries
+        // takes its name and its dates from the first of them, which is where it began.
+        return segments?[0];
+    }
+
+    /// <summary>
+    /// Picks the entry holding the given episode of a season. The episode number and the number
+    /// within the entry differ when Jellyfin numbers as one season what AniDB splits across
+    /// several entries: episode 13 of such a season is episode 1 of the second entry.
+    /// </summary>
+    /// <param name="segments">The entries the season is filled from.</param>
+    /// <param name="episodeNumber">The Jellyfin episode number.</param>
+    /// <returns>The segment holding the episode.</returns>
+    public static AniDbSeasonSegment PickSegment(IReadOnlyList<AniDbSeasonSegment> segments, int episodeNumber)
+    {
+        foreach (var segment in segments)
+        {
+            if (segment.EpisodeCount <= 0 || episodeNumber < segment.FirstEpisodeNumber + segment.EpisodeCount)
+            {
+                return segment;
+            }
+        }
+
+        // Past the last episode AniDB accounts for. The last entry is still the only one the
+        // episode can belong to; if it holds no such episode the lookup simply finds nothing.
+        return segments[^1];
+    }
+
+    /// <summary>
+    /// The AniDB entries the series spans, in season order, starting with the series entry.
+    /// Costs no AniDB request: it reuses a mapping already built, then follows sequel relations
+    /// only through documents already cached on disk. A library that has not been scanned yet
+    /// gets the part of the chain that is known.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series, which is also its first season.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB ids of the entries the series spans.</returns>
+    public static async Task<IReadOnlyList<string>> GetCachedSeasonChain(IApplicationPaths appPaths, string seriesId, CancellationToken cancellationToken)
+    {
+        var chain = new List<string> { seriesId };
+
+        if (Plugin.Instance.Configuration.IgnoreSeason)
+        {
+            return chain;
+        }
+
+        // A mapping already built went through the full checks, and reusing it keeps a
+        // season's specials with the entries that season was filled from.
+        foreach (var mapped in GetMappedChain(seriesId))
+        {
+            if (!chain.Contains(mapped, StringComparer.Ordinal))
+            {
+                chain.Add(mapped);
+            }
+        }
+
+        while (chain.Count < MaxSeasonsInChain)
+        {
+            var previous = await LoadCachedSummary(appPaths, chain[^1]).ConfigureAwait(false);
+            if (previous == null)
+            {
+                break;
+            }
+
+            var next = await FindCachedNextSeason(appPaths, previous, previous.SequelIds, chain, MaxInterludeHops, cancellationToken).ConfigureAwait(false);
+
+            if (next == null)
+            {
+                break;
+            }
+
+            chain.Add(next.Id);
+        }
+
+        return chain;
+    }
+
+    /// <summary>
+    /// Finds the entry that follows the given one, reading only documents already cached. Steps
+    /// over a movie or an OVA the same way the full walk does, so that a season reached only
+    /// through one still has its specials searched.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="previous">The entry to follow.</param>
+    /// <param name="candidateIds">The entries to consider.</param>
+    /// <param name="chain">The chain built so far, which nothing may repeat.</param>
+    /// <param name="hopsLeft">How many more movies or OVAs may be stepped over.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The next entry, or <c>null</c> when the cached documents do not reach one.</returns>
+    private static async Task<AniDbAnimeSummary?> FindCachedNextSeason(
+        IApplicationPaths appPaths,
+        AniDbAnimeSummary previous,
+        IReadOnlyList<string> candidateIds,
+        IReadOnlyList<string> chain,
+        int hopsLeft,
+        CancellationToken cancellationToken)
+    {
+        AniDbAnimeSummary? next = null;
+        var interludes = new List<AniDbAnimeSummary>();
+
+        foreach (var candidateId in candidateIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (chain.Contains(candidateId, StringComparer.Ordinal))
+            {
+                continue;
+            }
+
+            var candidate = await LoadCachedSummary(appPaths, candidateId).ConfigureAwait(false);
+
+            if (candidate == null)
+            {
+                continue;
+            }
+
+            if (!CanFollow(previous, candidate))
+            {
+                if (!_seasonAnimeTypes.Contains(candidate.Type, StringComparer.OrdinalIgnoreCase)
+                    && StartsAfter(previous, candidate))
+                {
+                    interludes.Add(candidate);
+                }
+
+                continue;
+            }
+
+            // Of everything that could follow this entry, the next season starts first.
+            if (next == null || (candidate.StartDate ?? DateTime.MaxValue) < (next.StartDate ?? DateTime.MaxValue))
+            {
+                next = candidate;
+            }
+        }
+
+        if (next != null || hopsLeft <= 0)
+        {
+            return next;
+        }
+
+        foreach (var interlude in interludes)
+        {
+            next = await FindCachedNextSeason(appPaths, previous, interlude.SequelIds, chain, hopsLeft - 1, cancellationToken).ConfigureAwait(false);
+
+            if (next != null)
+            {
+                return next;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The entries of every mapping already built for the series, in season order.
+    /// </summary>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <returns>The AniDB ids the series' seasons were mapped to.</returns>
+    private static IEnumerable<string> GetMappedChain(string seriesId)
+    {
+        var prefix = seriesId + "|";
+
+        foreach (var mapping in _mappings)
+        {
+            if (!mapping.Key.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var season in mapping.Value.OrderBy(entry => entry.Key))
+            {
+                foreach (var segment in season.Value)
+                {
+                    yield return segment.AnimeId;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The AniDB entries the given season is filled from, in the order its episodes run
+    /// through them.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="seasonNumber">The Jellyfin season number.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The segments, or <c>null</c> when the season cannot be identified.</returns>
+    public static async Task<IReadOnlyList<AniDbSeasonSegment>?> ResolveSeasonSegments(
+        IApplicationPaths appPaths,
+        ILibraryManager? libraryManager,
+        string seriesId,
+        int seasonNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var layout = AniDbSeasonLayout.Read(libraryManager, seriesId);
+        var placed = await PickPlacement(appPaths, seriesId, seasonNumber, layout, logger, cancellationToken).ConfigureAwait(false);
+
+        if (placed.Fitted.Count > 0)
+        {
+            return placed.Fitted;
+        }
+
+        var key = seriesId + "|" + (layout?.Signature ?? "-");
+
+        if (!_mappings.TryGetValue(key, out var mapping))
+        {
+            var gate = _mappingGates.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
+
+            await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                if (!_mappings.TryGetValue(key, out mapping))
+                {
+                    mapping = await BuildMapping(appPaths, seriesId, layout, logger, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+
+        if (mapping.TryGetValue(seasonNumber, out var segments))
+        {
+            return segments;
+        }
+
+        // A placement that does not account for the season is still better than nothing, and
+        // this is where nothing is what the chain came to.
+        if (placed.Partial.Count > 0)
+        {
+            return placed.Partial;
+        }
+
+        if (_reportedUnmapped.TryAdd(FormattableString.Invariant($"{key}/{seasonNumber}"), 0))
+        {
+            logger.LogWarning(
+                "Season {SeasonNumber} of AniDB series {SeriesId} could not be mapped to an AniDB entry. Nothing AniDB relates to the entries before it, or shares a title with them, can be that season. It and its episodes stay without metadata; set its AniDB id by hand to fill it in",
+                seasonNumber,
+                seriesId);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The placement of a season that holds up against what AniDB records, out of those the
+    /// mapping sources offer.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="seasonNumber">The season number.</param>
+    /// <param name="layout">How the series is laid out in the library, or <c>null</c> when it cannot be seen.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The placement that accounts for the season, and the fullest that does not.</returns>
+    private static async Task<(IReadOnlyList<AniDbSeasonSegment> Fitted, IReadOnlyList<AniDbSeasonSegment> Partial)> PickPlacement(
+        IApplicationPaths appPaths,
+        string seriesId,
+        int seasonNumber,
+        AniDbSeasonLayout? layout,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var placements = await AniDbMappings.ResolveSeasons(appPaths, seriesId, seasonNumber, logger, cancellationToken).ConfigureAwait(false);
+
+        if (placements.Count == 0)
+        {
+            return ([], []);
+        }
+
+        // Said once per season rather than once per episode. The placement is worked out afresh
+        // each time, cheaply, so that a mapping file downloaded since is acted on without
+        // waiting for a restart.
+        var reported = _reportedPlacements.TryAdd(FormattableString.Invariant($"{seriesId}/{seasonNumber}"), 0);
+        var wanted = layout?.Seasons.FirstOrDefault(season => season.Number == seasonNumber)?.EpisodeCount ?? 0;
+
+        SeasonPlacement? best = null;
+        var covered = 0;
+
+        foreach (var placement in placements)
+        {
+            var unheld = await FirstUnheldSegment(appPaths, placement.Segments).ConfigureAwait(false);
+
+            if (unheld != null)
+            {
+                if (reported)
+                {
+                    logger.LogWarning(
+                        "{Source} fill season {SeasonNumber} of AniDB series {SeriesId} from episode {EpisodeNumberInEntry} onwards of anime {AnimeId}, which AniDB records only {EpisodeCount} episodes for, so that placement is not used",
+                        placement.Source,
+                        seasonNumber,
+                        seriesId,
+                        unheld.Segment.FirstEpisodeInEntry,
+                        unheld.Segment.AnimeId,
+                        unheld.EpisodeCount);
+                }
+
+                continue;
+            }
+
+            // A placement written by hand is not weighed against anything: not against how far
+            // the other sources reach, and not against how long the library's season is. It
+            // says which episodes of which entry fill a season, AniDB holds them, and that is
+            // the whole of the question.
+            if (placement.Authoritative)
+            {
+                if (reported)
+                {
+                    logger.LogInformation(
+                        "Season {SeasonNumber} of AniDB series {SeriesId} is filled with {Placement}, where {Source} place it",
+                        seasonNumber,
+                        seriesId,
+                        string.Join(", ", placement.Segments.Select(SeasonSegments.Describe)),
+                        placement.Source);
+                }
+
+                return (placement.Segments, []);
+            }
+
+            var reach = Reach(placement.Segments);
+
+            if (best == null || reach > covered)
+            {
+                best = placement;
+                covered = reach;
+            }
+
+            // Nothing beats accounting for the whole season, and where the library cannot say
+            // how long the season is there is nothing to compare by, so the first source to
+            // answer keeps its precedence.
+            if (wanted <= 0 || covered >= wanted)
+            {
+                break;
+            }
+        }
+
+        if (best == null)
+        {
+            return ([], []);
+        }
+
+        // A placement that leaves episodes of the season unaccounted for is not describing this
+        // library's season. Inuyasha is the case that shows why: TVDB has since merged what the
+        // sources still call its sixth and seventh seasons, so from the sixth on their numbering
+        // runs one ahead of the library's, and the season holding the Final Act is given the
+        // last eight episodes of the original series instead. Laying the chain of entries over
+        // the seasons the library actually has gets that right, so it is given the chance to,
+        // and this is kept only for where the chain comes to nothing.
+        var fits = wanted <= 0 || covered >= wanted;
+
+        if (reported)
+        {
+            if (fits)
+            {
+                logger.LogInformation(
+                    "Season {SeasonNumber} of AniDB series {SeriesId} is filled with {Placement}, where {Source} place it",
+                    seasonNumber,
+                    seriesId,
+                    string.Join(", ", best.Segments.Select(SeasonSegments.Describe)),
+                    best.Source);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "{Source} account for {Covered} of the {Wanted} episodes the library holds under season {SeasonNumber} of AniDB series {SeriesId}, so that placement is not used and the season is worked out from AniDB's own relations instead. The mapping file is describing a different season layout from the one the library has",
+                    best.Source,
+                    covered,
+                    wanted,
+                    seasonNumber,
+                    seriesId);
+            }
+        }
+
+        return fits ? (best.Segments, []) : ([], best.Segments);
+    }
+
+    /// <summary>
+    /// How many of a season's episodes a placement accounts for.
+    /// </summary>
+    /// <remarks>
+    /// A source that describes only part of a season - AniBridge maps one episode of Ginga
+    /// Eiyuu Densetsu: Die Neue These's later seasons and leaves the other eleven to its own
+    /// scope for AniDB's other episode types, which nothing here reads - would otherwise be
+    /// preferred over one that describes all of it, its answer being neither empty nor wrong
+    /// about the episode it does name.
+    /// </remarks>
+    /// <param name="segments">The segments the placement is made of.</param>
+    /// <returns>The episode count, or <see cref="int.MaxValue"/> where a segment runs to the end of the season.</returns>
+    private static int Reach(IReadOnlyList<AniDbSeasonSegment> segments)
+    {
+        var reach = 0;
+
+        foreach (var segment in segments)
+        {
+            if (segment.EpisodeCount <= 0)
+            {
+                return int.MaxValue;
+            }
+
+            reach += segment.EpisodeCount;
+        }
+
+        return reach;
+    }
+
+    /// <summary>
+    /// The first segment of a placement that names episodes the entry it names does not have.
+    /// </summary>
+    /// <remarks>
+    /// The mapping sources report tens of thousands of range inconsistencies among themselves,
+    /// and a segment reaching past the end of its entry is the one kind that can be checked
+    /// here for nothing: the entry's episode count is in a document already on disk. An entry
+    /// that is not cached cannot be checked, and is taken at the source's word rather than
+    /// spending a request to doubt it.
+    /// </remarks>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="segments">The segments the placement is made of.</param>
+    /// <returns>The offending segment and the entry's episode count, or <c>null</c> where every segment holds up.</returns>
+    private static async Task<UnheldSegment?> FirstUnheldSegment(IApplicationPaths appPaths, IReadOnlyList<AniDbSeasonSegment> segments)
+    {
+        foreach (var segment in segments)
+        {
+            // AniDB counts an entry's ordinary episodes and nothing else, so a segment reading
+            // from another of its numberings has nothing here to be checked against.
+            if (segment.Kind != AniDbEpisodeKind.Regular)
+            {
+                continue;
+            }
+
+            var episodeCount = await GetCachedEpisodeCount(appPaths, segment.AnimeId).ConfigureAwait(false);
+
+            // Nothing on disk to check against. AniDB also counts an anime still airing as the
+            // episodes it will have, so a segment reaching into a season part way through
+            // airing is not an inconsistency.
+            if (episodeCount <= 0)
+            {
+                continue;
+            }
+
+            // A segment with no count runs to the end of the season, so only where it starts
+            // can be checked.
+            var last = segment.EpisodeCount > 0
+                ? segment.FirstEpisodeInEntry + segment.EpisodeCount - 1
+                : segment.FirstEpisodeInEntry;
+
+            if (last > episodeCount)
+            {
+                return new UnheldSegment(segment, episodeCount);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// How many episodes AniDB records for an entry, read from the document already on disk.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of the entry.</param>
+    /// <returns>The episode count, or 0 where the entry is not cached or records none.</returns>
+    private static async Task<int> GetCachedEpisodeCount(IApplicationPaths appPaths, string animeId)
+    {
+        var path = Path.Combine(AniDbSeriesProvider.GetSeriesDataPath(appPaths, animeId), "series.xml");
+        var file = new FileInfo(path);
+
+        if (!file.Exists || file.Length == 0)
+        {
+            return 0;
+        }
+
+        if (_episodeCounts.TryGetValue(animeId, out var known) && known.WrittenAtUtc == file.LastWriteTimeUtc)
+        {
+            return known.EpisodeCount;
+        }
+
+        var summary = await ParseSummary(animeId, path).ConfigureAwait(false);
+
+        _episodeCounts[animeId] = (file.LastWriteTimeUtc, summary.EpisodeCount);
+
+        return summary.EpisodeCount;
+    }
+
+    /// <summary>
+    /// Lays the chain of AniDB entries over the seasons the library has, giving each season the
+    /// entries whose episodes it covers.
+    /// </summary>
+    /// <remarks>
+    /// AniDB and the provider that numbers the seasons do not agree on where a season ends: a
+    /// season released in two cours is two AniDB entries and one season everywhere else.
+    /// Counting one entry per season therefore slips a place at the first such split and gets
+    /// every later season wrong, which is why the episode numbers a season spans are what the
+    /// chain is laid against. Without a layout to lay it against there is nothing to correct
+    /// with, and one entry per season is all that can be assumed.
+    /// </remarks>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="layout">How the series is laid out in the library, or <c>null</c> when it cannot be seen.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The entries each season is filled from.</returns>
+    private static async Task<IReadOnlyDictionary<int, IReadOnlyList<AniDbSeasonSegment>>> BuildMapping(
+        IApplicationPaths appPaths,
+        string seriesId,
+        AniDbSeasonLayout? layout,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var mapping = new Dictionary<int, IReadOnlyList<AniDbSeasonSegment>>();
+
+        // Left outside the ban handling below: a ban on the series' own entry is what the
+        // providers report, and there is nothing to map without it.
+        var first = await LoadSummary(appPaths, seriesId, cancellationToken).ConfigureAwait(false);
+
+        if (first == null)
+        {
+            return mapping;
+        }
+
+        var chain = new List<AniDbAnimeSummary> { first };
+        var chainIndex = 0;
+
+        // How many episodes of the entry at that position earlier seasons have already taken.
+        var consumedInEntry = 0;
+        var complete = true;
+
+        foreach (var season in layout?.Seasons ?? GetAssumedSeasons())
+        {
+            if (season.Number <= 0)
+            {
+                continue;
+            }
+
+            var segments = new List<AniDbSeasonSegment>();
+            var covered = 0;
+
+            while (true)
+            {
+                var (entry, banned) = await GetChainEntry(appPaths, seriesId, chain, chainIndex, logger, cancellationToken).ConfigureAwait(false);
+
+                complete &= !banned;
+
+                if (entry == null)
+                {
+                    break;
+                }
+
+                var (count, outlastsSeason) = Allocate(entry.EpisodeCount, consumedInEntry, season.EpisodeCount, covered);
+
+                segments.Add(new AniDbSeasonSegment(entry.Id, season.FirstEpisodeNumber + covered, count, consumedInEntry + 1));
+                covered += count;
+
+                if (outlastsSeason)
+                {
+                    consumedInEntry += count;
+                }
+                else
+                {
+                    chainIndex++;
+                    consumedInEntry = 0;
+                }
+
+                if (season.EpisodeCount - covered < MinimumSplitEpisodes || segments.Count >= MaxSegmentsPerSeason)
+                {
+                    break;
+                }
+            }
+
+            if (segments.Count == 0)
+            {
+                break;
+            }
+
+            mapping[season.Number] = segments;
+
+            if (segments.Count > 1)
+            {
+                logger.LogInformation(
+                    "Season {SeasonNumber} of AniDB series {SeriesId} spans {EntryCount} AniDB entries, {AnimeIds}, because it covers {EpisodeCount} episodes and no single entry does",
+                    season.Number,
+                    seriesId,
+                    segments.Count,
+                    string.Join(", ", segments.Select(segment => segment.AnimeId)),
+                    season.EpisodeCount);
+            }
+            else
+            {
+                logger.LogInformation(
+                    "Season {SeasonNumber} of AniDB series {SeriesId} is anime {SeasonId}",
+                    season.Number,
+                    seriesId,
+                    segments[0].AnimeId);
+            }
+        }
+
+        if (layout == null)
+        {
+            logger.LogInformation(
+                "AniDB series {SeriesId} was mapped one entry per season, because its seasons could not be read from the library. A season AniDB splits in two will be off by one entry from there on; refreshing it once the episodes are in the library corrects that",
+                seriesId);
+        }
+
+        // A mapping cut short by a ban would otherwise be reused for as long as the server runs.
+        if (complete)
+        {
+            _mappings[seriesId + "|" + (layout?.Signature ?? "-")] = mapping;
+        }
+
+        return mapping;
+    }
+
+    /// <summary>
+    /// How much of an entry one season takes, and whether the entry runs on past it.
+    /// </summary>
+    /// <remarks>
+    /// An entry with more episodes left than the season has room for is one that the season
+    /// numbering breaks into several seasons, as a long-running show kept as a single AniDB
+    /// entry is: Dragon Ball Z is one entry of 291 episodes that TVDB splits into nine. Such an
+    /// entry gives this season what fits and keeps the rest for the next one. Taking a fresh
+    /// entry per season instead left every season past the first with nothing, the chain having
+    /// run out after one.
+    /// </remarks>
+    /// <param name="entryEpisodeCount">How many episodes AniDB records for the entry, or 0 where it records none.</param>
+    /// <param name="consumedInEntry">How many of the entry's episodes earlier seasons have taken.</param>
+    /// <param name="seasonEpisodeCount">How many episode numbers the season spans, or 0 where the library cannot be read.</param>
+    /// <param name="covered">How many of the season's episodes the segments so far account for.</param>
+    /// <returns>How many episodes this season takes from the entry, and whether the entry has episodes left over.</returns>
+    private static (int Count, bool OutlastsSeason) Allocate(int entryEpisodeCount, int consumedInEntry, int seasonEpisodeCount, int covered)
+    {
+        var room = Math.Max(seasonEpisodeCount - covered, 0);
+
+        // An entry AniDB gives no episode count for takes whatever the season has left, so that
+        // it is never the reason a second entry is pulled in. Without a season length to fit it
+        // to there is nothing to split against either, and the entry answers for the season
+        // whole, which is what a library that cannot be read has always been given.
+        if (entryEpisodeCount <= 0 || seasonEpisodeCount <= 0)
+        {
+            return (entryEpisodeCount > 0 ? entryEpisodeCount - consumedInEntry : room, false);
+        }
+
+        var left = entryEpisodeCount - consumedInEntry;
+
+        return left > room ? (room, true) : (left, false);
+    }
+
+    /// <summary>
+    /// Reads the entry at the given position of the chain, extending the chain to reach it.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="seriesId">The AniDB id of the series.</param>
+    /// <param name="chain">The chain built so far.</param>
+    /// <param name="index">The position wanted.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The entry, or <c>null</c> when the chain ends before it, and whether a ban stopped the walk.</returns>
+    private static async Task<(AniDbAnimeSummary? Entry, bool Banned)> GetChainEntry(
+        IApplicationPaths appPaths,
+        string seriesId,
+        List<AniDbAnimeSummary> chain,
+        int index,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        while (chain.Count <= index && chain.Count < MaxSeasonsInChain)
+        {
+            string? nextId;
+
+            try
+            {
+                nextId = await ResolveNextSeason(appPaths, seriesId, chain[^1], chain.Count + 1, logger, cancellationToken).ConfigureAwait(false);
+            }
+            catch (AniDbBannedException)
+            {
+                logger.LogDebug(
+                    "The chain of AniDB series {SeriesId} could not be walked past anime {AnimeId} because AniDB has banned this client",
+                    seriesId,
+                    chain[^1].Id);
+
+                return (null, true);
+            }
+
+            if (string.IsNullOrEmpty(nextId) || chain.Exists(entry => string.Equals(entry.Id, nextId, StringComparison.Ordinal)))
+            {
+                return (null, false);
+            }
+
+            var next = await LoadSummary(appPaths, nextId, cancellationToken).ConfigureAwait(false);
+
+            if (next == null)
+            {
+                return (null, false);
+            }
+
+            chain.Add(next);
+        }
+
+        return (index < chain.Count ? chain[index] : null, false);
+    }
+
+    /// <summary>
+    /// The seasons assumed when the library cannot be read: as many as the chain of AniDB
+    /// entries turns out to have, one entry each.
+    /// </summary>
+    /// <returns>The assumed seasons.</returns>
+    private static IEnumerable<AniDbLibrarySeason> GetAssumedSeasons()
+    {
+        for (var season = 1; season <= MaxSeasonsInChain; season++)
+        {
+            yield return new AniDbLibrarySeason(season, 1, 0);
+        }
+    }
+
+    /// <summary>
+    /// Whether a name is asking for one season of a show rather than for the show itself, as a
+    /// folder named "Show Season 2" is.
+    /// </summary>
+    /// <remarks>
+    /// A season is also named by the word for it in another language, and by the name a final
+    /// season is given instead of a number: AniDB files fifteen entries as "Kanketsuhen" and
+    /// titles them "The Final Act" in English, InuYasha's eighth season among them. Such a name
+    /// read as the show's own took the show's first entry and left the season it asked for
+    /// unidentified.
+    /// </remarks>
+    /// <param name="name">The name the series was searched under.</param>
+    /// <returns><c>true</c> when the name ends in a season marker.</returns>
+    public static bool NamesASeason(string? name)
+        => SeasonMarkerRegex().IsMatch(name ?? string.Empty);
+
+    /// <summary>
+    /// Walks a name match back to the first season of the show it belongs to.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id the name search produced.</param>
+    /// <param name="seriesName">The name the series was searched under.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB id of the first season, or the given id when it already is one.</returns>
+    public static async Task<string> ResolveFirstSeasonId(
+        IApplicationPaths appPaths,
+        string animeId,
+        string? seriesName,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        // A folder that names a season is asking for that season, not for the show.
+        if (string.IsNullOrEmpty(animeId) || NamesASeason(seriesName))
+        {
+            return animeId;
+        }
+
+        var currentId = animeId;
+
+        try
+        {
+            currentId = await WalkToFirstSeason(appPaths, animeId, seriesName, logger, cancellationToken).ConfigureAwait(false);
+        }
+        catch (AniDbBannedException)
+        {
+            // The matched entry may be cached while its prequel is not. Keep the match
+            // rather than lose metadata already on disk.
+            logger?.LogDebug("Anime {AnimeId} could not be checked for an earlier season because AniDB has banned this client", animeId);
+        }
+
+        return currentId;
+    }
+
+    private static async Task<string> WalkToFirstSeason(
+        IApplicationPaths appPaths,
+        string animeId,
+        string? seriesName,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        var currentId = animeId;
+
+        for (var hop = 0; hop < MaxPrequelHops; hop++)
+        {
+            var current = await LoadSummary(appPaths, currentId, cancellationToken).ConfigureAwait(false);
+
+            // Only an entry with a prequel can be a later season.
+            if (current == null || current.PrequelIds.Count == 0)
+            {
+                break;
+            }
+
+            string? earlierId = null;
+
+            foreach (var prequelId in current.PrequelIds)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var candidate = await LoadSummary(appPaths, prequelId, cancellationToken).ConfigureAwait(false);
+
+                // AniDB records a prequel relation between any two shows that follow each
+                // other, including ones Jellyfin keeps apart. Only a title continued by
+                // number is the same show.
+                if (candidate != null
+                    && _seasonAnimeTypes.Contains(candidate.Type, StringComparer.OrdinalIgnoreCase)
+                    && IsNumberedContinuation(candidate.Titles, current.Titles))
+                {
+                    earlierId = candidate.Id;
+
+                    break;
+                }
+            }
+
+            if (earlierId == null)
+            {
+                break;
+            }
+
+            logger?.LogInformation(
+                "The name {SeriesName} matched anime {MatchedId}, which is a later season of anime {FirstId}. Using the earlier entry, so that the seasons below it resolve from the start of the show",
+                seriesName,
+                currentId,
+                earlierId);
+
+            currentId = earlierId;
+        }
+
+        return currentId;
+    }
+
+    private static async Task<string?> ResolveNextSeason(
+        IApplicationPaths appPaths,
+        string seriesId,
+        AniDbAnimeSummary previous,
+        int seasonNumber,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var previousId = previous.Id;
+
+        // Sequel relations catch the seasons that were renamed rather than numbered, and
+        // never turn up an anime that merely shares a title. Read from the previous season's
+        // cached document, so the route costs nothing.
+        var related = previous.SequelIds
+            .Where(sequelId => !string.Equals(sequelId, previousId, StringComparison.Ordinal))
+            .ToList();
+
+        var fromRelations = await ChooseNextSeason(appPaths, previous, related, logger, cancellationToken).ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(fromRelations))
+        {
+            return fromRelations;
+        }
+
+        // A movie or an OVA released between two seasons carries the chain on: AniDB relates
+        // the next season to that release rather than to the season before it, so a season
+        // whose only sequel is one would otherwise be the end of the show. It is stepped over
+        // rather than mapped, Jellyfin having it as an item of its own.
+        var beyond = await ChooseNextSeasonBeyond(appPaths, previous, related, [previousId], MaxInterludeHops, logger, cancellationToken).ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(beyond))
+        {
+            return beyond;
+        }
+
+        // No usable relation, which is also how an entry with none recorded looks. The titles
+        // file is already in memory, so a sequel titled with its season number costs no
+        // request; a hit there still has to pass the same checks.
+        var series = string.Equals(previousId, seriesId, StringComparison.Ordinal)
+            ? previous
+            : await LoadSummary(appPaths, seriesId, cancellationToken).ConfigureAwait(false);
+
+        if (series == null)
+        {
+            return null;
+        }
+
+        var titled = new List<string>();
+
+        foreach (var title in GetSeasonTitles(series.Titles, seasonNumber))
+        {
+            var id = await LookupTitle(title, cancellationToken).ConfigureAwait(false);
+
+            if (!string.IsNullOrEmpty(id)
+                && !string.Equals(id, previousId, StringComparison.Ordinal)
+                && !related.Contains(id, StringComparer.Ordinal)
+                && !titled.Contains(id, StringComparer.Ordinal))
+            {
+                titled.Add(id);
+            }
+        }
+
+        return await ChooseNextSeason(appPaths, previous, titled, logger, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<string?> ChooseNextSeason(
+        IApplicationPaths appPaths,
+        AniDbAnimeSummary previous,
+        IReadOnlyList<string> candidateIds,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var survivors = new List<AniDbAnimeSummary>();
+        var read = 0;
+
+        foreach (var candidateId in candidateIds)
+        {
+            if (read++ >= MaxCandidatesPerRoute)
+            {
+                break;
+            }
+
+            var candidate = await LoadSummary(appPaths, candidateId, cancellationToken).ConfigureAwait(false);
+
+            if (candidate == null)
+            {
+                logger.LogDebug("Candidate {CandidateId} to follow anime {PreviousId} could not be read", candidateId, previous.Id);
+
+                continue;
+            }
+
+            var usable = CanFollow(previous, candidate);
+
+            logger.LogDebug(
+                "Candidate {CandidateId} to follow anime {PreviousId} is a {Type} that aired {StartDate} to {EndDate}, related {Related}, usable {Usable}",
+                candidateId,
+                previous.Id,
+                candidate.Type,
+                candidate.StartDate,
+                candidate.EndDate,
+                IsRelated(previous, candidate),
+                usable);
+
+            if (usable)
+            {
+                survivors.Add(candidate);
+            }
+        }
+
+        // Of everything that could follow this season, the next one starts first. A related
+        // anime outranks one that only matched by title.
+        return survivors
+            .OrderBy(candidate => IsRelated(previous, candidate) ? 0 : 1)
+            .ThenBy(candidate => candidate.StartDate ?? DateTime.MaxValue)
+            .FirstOrDefault()?.Id;
+    }
+
+    private static async Task<string?> ChooseNextSeasonBeyond(
+        IApplicationPaths appPaths,
+        AniDbAnimeSummary previous,
+        IReadOnlyList<string> candidateIds,
+        IReadOnlyCollection<string> seen,
+        int hopsLeft,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (hopsLeft <= 0)
+        {
+            return null;
+        }
+
+        var visited = new HashSet<string>(seen, StringComparer.Ordinal);
+        visited.UnionWith(candidateIds);
+
+        var onwards = new List<string>();
+        var read = 0;
+
+        foreach (var candidateId in candidateIds)
+        {
+            if (read++ >= MaxCandidatesPerRoute)
+            {
+                break;
+            }
+
+            // Already read on the route above, so this comes off the disk rather than AniDB.
+            var interlude = await LoadSummary(appPaths, candidateId, cancellationToken).ConfigureAwait(false);
+
+            // Only something released after this season can stand between it and the next one,
+            // and only something that is not a season itself needs stepping over.
+            if (interlude == null
+                || _seasonAnimeTypes.Contains(interlude.Type, StringComparer.OrdinalIgnoreCase)
+                || !StartsAfter(previous, interlude))
+            {
+                continue;
+            }
+
+            foreach (var sequelId in interlude.SequelIds)
+            {
+                if (visited.Add(sequelId))
+                {
+                    onwards.Add(sequelId);
+                }
+            }
+        }
+
+        if (onwards.Count == 0)
+        {
+            return null;
+        }
+
+        logger.LogDebug(
+            "Nothing AniDB relates to anime {PreviousId} is a season, so the {Count} anime beyond the movies, specials and OVAs that follow it are tried instead",
+            previous.Id,
+            onwards.Count);
+
+        var found = await ChooseNextSeason(appPaths, previous, onwards, logger, cancellationToken).ConfigureAwait(false);
+
+        // A season can sit behind more than one release, as a movie followed by a recap special.
+        return string.IsNullOrEmpty(found)
+            ? await ChooseNextSeasonBeyond(appPaths, previous, onwards, visited, hopsLeft - 1, logger, cancellationToken).ConfigureAwait(false)
+            : found;
+    }
+
+    /// <summary>
+    /// Whether the candidate was released after the given anime began. Looser than
+    /// <see cref="CanFollow"/>, which asks whether one season follows another: a movie released
+    /// between two seasons routinely comes out while the first is still on the air.
+    /// </summary>
+    /// <param name="previous">The anime the candidate would come after.</param>
+    /// <param name="candidate">The candidate.</param>
+    /// <returns>Whether the candidate came later.</returns>
+    private static bool StartsAfter(AniDbAnimeSummary previous, AniDbAnimeSummary candidate)
+        => !candidate.StartDate.HasValue
+            || !previous.StartDate.HasValue
+            || candidate.StartDate > previous.StartDate;
+
+    private static bool CanFollow(AniDbAnimeSummary previous, AniDbAnimeSummary candidate)
+    {
+        if (!_seasonAnimeTypes.Contains(candidate.Type, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!candidate.StartDate.HasValue)
+        {
+            // AniDB leaves the date off anime that have only been announced. Nothing here
+            // can rule this one out.
+            return true;
+        }
+
+        // A season starts once the one before it has finished airing. The end date is what
+        // separates the next season from an entry that ran alongside this one; the start date
+        // alone does not.
+        if (previous.EndDate.HasValue)
+        {
+            return candidate.StartDate >= previous.EndDate.Value - _airingOverlapAllowance;
+        }
+
+        // Still airing, or no end date recorded: whatever follows cannot have started first.
+        return !previous.StartDate.HasValue || candidate.StartDate > previous.StartDate;
+    }
+
+    /// <summary>
+    /// Whether any title of the later entry is a title of the earlier one followed by
+    /// nothing but a season number.
+    /// </summary>
+    /// <param name="earlierTitles">The titles of the earlier entry.</param>
+    /// <param name="laterTitles">The titles of the later entry.</param>
+    /// <returns>Whether the later entry continues the earlier one by number.</returns>
+    private static bool IsNumberedContinuation(IReadOnlyList<string> earlierTitles, IReadOnlyList<string> laterTitles)
+    {
+        foreach (var earlier in earlierTitles)
+        {
+            var prefix = NormalizeTitle(earlier);
+
+            // Short titles match far too much once punctuation is gone.
+            if (prefix.Length < 4)
+            {
+                continue;
+            }
+
+            foreach (var later in laterTitles)
+            {
+                var full = NormalizeTitle(later);
+
+                if (full.Length > prefix.Length
+                    && full.StartsWith(prefix, StringComparison.Ordinal)
+                    && SeasonSuffixRegex().IsMatch(full[prefix.Length..]))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reduces a title to its letters and digits, upper cased, so that punctuation and
+    /// spacing cannot keep two spellings of the same name apart.
+    /// </summary>
+    /// <param name="value">The title to reduce.</param>
+    /// <returns>The reduced title.</returns>
+    private static string NormalizeTitle(string value)
+        => string.Concat(value.Where(char.IsLetterOrDigit)).ToUpperInvariant();
+
+    private static bool IsRelated(AniDbAnimeSummary previous, AniDbAnimeSummary candidate)
+        => previous.SequelIds.Contains(candidate.Id, StringComparer.Ordinal)
+            || candidate.PrequelIds.Contains(previous.Id, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Builds the titles the given season would have if AniDB numbered it.
+    /// </summary>
+    /// <param name="seriesTitles">The titles of the series.</param>
+    /// <param name="seasonNumber">The season number.</param>
+    /// <returns>The candidate titles.</returns>
+    private static IEnumerable<string> GetSeasonTitles(IReadOnlyList<string> seriesTitles, int seasonNumber)
+    {
+        var number = seasonNumber.ToString(CultureInfo.InvariantCulture);
+
+        var suffixes = new List<string>
+        {
+            "Season " + number,
+            number,
+            GetOrdinal(seasonNumber) + " Season"
+        };
+
+        if (seasonNumber >= 2 && seasonNumber - 2 < _romanNumerals.Length)
+        {
+            suffixes.Add(_romanNumerals[seasonNumber - 2]);
+        }
+
+        foreach (var title in seriesTitles)
+        {
+            foreach (var suffix in suffixes)
+            {
+                yield return title + " " + suffix;
+            }
+        }
+    }
+
+    private static string GetOrdinal(int value)
+    {
+        var suffix = (value % 100) is >= 11 and <= 13
+            ? "th"
+            : (value % 10) switch
+            {
+                1 => "st",
+                2 => "nd",
+                3 => "rd",
+                _ => "th"
+            };
+
+        return value.ToString(CultureInfo.InvariantCulture) + suffix;
+    }
+
+    private static async Task<string?> LookupTitle(string title, CancellationToken cancellationToken)
+    {
+        var matcher = AniDbTitleMatcher.DefaultInstance;
+
+        if (matcher == null)
+        {
+            return null;
+        }
+
+        return await matcher.FindSeries(title, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads an entry's summary only if it is already cached, so that a miss costs nothing.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of the entry.</param>
+    /// <returns>The summary, or <c>null</c> when the entry is not cached.</returns>
+    private static async Task<AniDbAnimeSummary?> LoadCachedSummary(IApplicationPaths appPaths, string animeId)
+    {
+        var seriesDataPath = Path.Combine(AniDbSeriesProvider.GetSeriesDataPath(appPaths, animeId), "series.xml");
+        var fileInfo = new FileInfo(seriesDataPath);
+
+        if (!fileInfo.Exists || fileInfo.Length == 0)
+        {
+            return null;
+        }
+
+        return await ParseSummary(animeId, seriesDataPath).ConfigureAwait(false);
+    }
+
+    private static async Task<AniDbAnimeSummary?> LoadSummary(IApplicationPaths appPaths, string animeId, CancellationToken cancellationToken)
+    {
+        var seriesDataPath = await AniDbSeriesProvider.GetSeriesData(appPaths, animeId, cancellationToken).ConfigureAwait(false);
+
+        if (!File.Exists(seriesDataPath))
+        {
+            return null;
+        }
+
+        return await ParseSummary(animeId, seriesDataPath).ConfigureAwait(false);
+    }
+
+    private static async Task<AniDbAnimeSummary> ParseSummary(string animeId, string seriesDataPath)
+    {
+        var settings = new XmlReaderSettings
+        {
+            Async = true,
+            CheckCharacters = false,
+            IgnoreProcessingInstructions = true,
+            IgnoreComments = true,
+            ValidationType = ValidationType.None
+        };
+
+        string? type = null;
+        var episodeCount = 0;
+        DateTime? startDate = null;
+        DateTime? endDate = null;
+        var titles = new List<string>();
+        var sequelIds = new List<string>();
+        var prequelIds = new List<string>();
+
+        using (var streamReader = new StreamReader(seriesDataPath, Encoding.UTF8))
+        using (var reader = XmlReader.Create(streamReader, settings))
+        {
+            await reader.MoveToContentAsync().ConfigureAwait(false);
+
+            var done = false;
+
+            while (!done && await reader.ReadAsync().ConfigureAwait(false))
+            {
+                if (reader.NodeType != XmlNodeType.Element)
+                {
+                    continue;
+                }
+
+                switch (reader.Name)
+                {
+                    case "type":
+                        type = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
+                        break;
+
+                    case "episodecount":
+                        _ = int.TryParse(
+                            await reader.ReadElementContentAsStringAsync().ConfigureAwait(false),
+                            CultureInfo.InvariantCulture,
+                            out episodeCount);
+                        break;
+
+                    case "startdate":
+                        startDate = ParseDate(await reader.ReadElementContentAsStringAsync().ConfigureAwait(false));
+                        break;
+
+                    case "enddate":
+                        endDate = ParseDate(await reader.ReadElementContentAsStringAsync().ConfigureAwait(false));
+                        break;
+
+                    case "titles":
+                        await ReadTitles(reader, titles).ConfigureAwait(false);
+                        break;
+
+                    case "relatedanime":
+                        await ReadRelations(reader, sequelIds, prequelIds).ConfigureAwait(false);
+                        break;
+
+                    case "characters":
+                    case "episodes":
+                        // Everything read here comes before these two, which hold the bulk
+                        // of the document.
+                        done = true;
+                        break;
+                }
+            }
+        }
+
+        return new AniDbAnimeSummary
+        {
+            Id = animeId,
+            Type = type,
+            EpisodeCount = episodeCount,
+            StartDate = startDate,
+            EndDate = endDate,
+            Titles = titles,
+            SequelIds = sequelIds,
+            PrequelIds = prequelIds
+        };
+    }
+
+    private static async Task ReadTitles(XmlReader reader, List<string> titles)
+    {
+        using var subtree = reader.ReadSubtree();
+
+        while (await subtree.ReadAsync().ConfigureAwait(false))
+        {
+            if (subtree.NodeType == XmlNodeType.Element && subtree.Name == "title")
+            {
+                var title = await subtree.ReadElementContentAsStringAsync().ConfigureAwait(false);
+
+                if (!string.IsNullOrWhiteSpace(title) && !titles.Contains(title, StringComparer.Ordinal))
+                {
+                    titles.Add(title);
+                }
+            }
+        }
+    }
+
+    private static async Task ReadRelations(XmlReader reader, List<string> sequelIds, List<string> prequelIds)
+    {
+        using var subtree = reader.ReadSubtree();
+
+        while (await subtree.ReadAsync().ConfigureAwait(false))
+        {
+            if (subtree.NodeType != XmlNodeType.Element || subtree.Name != "anime")
+            {
+                continue;
+            }
+
+            var relatedId = subtree.GetAttribute("id");
+
+            if (string.IsNullOrEmpty(relatedId))
+            {
+                continue;
+            }
+
+            // AniDB relates anime in many ways. Only the two that order a series matter.
+            var relation = subtree.GetAttribute("type");
+            List<string>? relatedIds = null;
+
+            if (string.Equals(relation, "Sequel", StringComparison.OrdinalIgnoreCase))
+            {
+                relatedIds = sequelIds;
+            }
+            else if (string.Equals(relation, "Prequel", StringComparison.OrdinalIgnoreCase))
+            {
+                relatedIds = prequelIds;
+            }
+
+            if (relatedIds != null && !relatedIds.Contains(relatedId, StringComparer.Ordinal))
+            {
+                relatedIds.Add(relatedId);
+            }
+        }
+    }
+
+    private static DateTime? ParseDate(string? value)
+    {
+        // AniDB reports a calendar date with no time and no zone. AssumeUniversal keeps it as
+        // written rather than shifting it by the server's offset.
+        if (!string.IsNullOrWhiteSpace(value)
+            && DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var date))
+        {
+            return date;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// A season number, as it is written at the end of a folder name.
+    /// </summary>
+    /// <remarks>
+    /// The Roman numeral is the one part matched as written, case and all, because a romanized
+    /// Japanese title ends in those same letters as words of its own: "Raise wa Tanin ga Ii"
+    /// ends in "Ii", which read case-insensitively is season two. A numeral is written in
+    /// capitals wherever it means a number, so requiring them costs nothing.
+    /// <para>
+    /// A lone V or X is left out altogether. Either can end a title as a letter - "Nazo no
+    /// Kanojo X", "After War Gundam X" - where no title reaches a fifth or tenth season
+    /// written as a numeral rather than a number.
+    /// </para>
+    /// </remarks>
+    [GeneratedRegex(@"(\b(season|staffel|part|series|stage|cour)\s*\d+|\b\d+(st|nd|rd|th)\s+(season|staffel|part|series|stage|cour)|\b\d+\.\s*(season|staffel|part|series|stage|cour)|\b(final\s+(season|act|chapter))|\bkanketsuhen|(?-i:\s(II|III|IV|VI|VII|VIII|IX)))\s*$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SeasonMarkerRegex();
+
+    /// <summary>
+    /// What may follow a title for it still to be the same show, one season on. Matched
+    /// against a title reduced by <see cref="NormalizeTitle"/>.
+    /// </summary>
+    [GeneratedRegex(@"^(?:(?:SEASON|PART|SERIES|STAGE|COUR)?(?:[2-9]|1[0-9])(?:ST|ND|RD|TH)?(?:SEASON|PART|SERIES|STAGE|COUR)?|II|III|IV|V|VI|VII|VIII|IX|X|(?:SECOND|THIRD|FOURTH|FIFTH|SIXTH|FINAL)(?:SEASON|PART|SERIES|STAGE|COUR)?)$", RegexOptions.CultureInvariant)]
+    private static partial Regex SeasonSuffixRegex();
+
+    /// <summary>
+    /// A segment naming episodes its entry does not have.
+    /// </summary>
+    /// <param name="Segment">The segment.</param>
+    /// <param name="EpisodeCount">How many episodes AniDB records for the entry it names.</param>
+    private sealed record UnheldSegment(AniDbSeasonSegment Segment, int EpisodeCount);
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonSegment.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonSegment.cs
@@ -1,0 +1,18 @@
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+/// <summary>
+/// One AniDB entry, or part of one, that a Jellyfin season is filled from. A season usually has
+/// a single segment, and has more than one when the season Jellyfin numbers is split across
+/// several AniDB entries, as a season released in two cours is.
+/// </summary>
+/// <param name="AnimeId">The AniDB id of the entry.</param>
+/// <param name="FirstEpisodeNumber">The Jellyfin episode number the segment starts at.</param>
+/// <param name="EpisodeCount">How many episodes the segment holds, or zero when it runs to the end of the season.</param>
+/// <param name="FirstEpisodeInEntry">The entry's own number for that first episode. Not 1 when a season starts part way into an entry, as the second half of a series split across two seasons does.</param>
+/// <param name="Kind">Which of the entry's episode numberings those numbers belong to. Ordinary episodes unless the season is filled from the entry's other episodes, as a season of movies broadcast as television episodes is.</param>
+internal sealed record AniDbSeasonSegment(
+    string AnimeId,
+    int FirstEpisodeNumber,
+    int EpisodeCount,
+    int FirstEpisodeInEntry = 1,
+    AniDbEpisodeKind Kind = AniDbEpisodeKind.Regular);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -1153,7 +1153,12 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         }
 
         string? title = titles.Localize(Plugin.Instance.Configuration.TitlePreference, preferredMetadataLangauge)?.Name;
-        string? originalTitle = titles.Localize(Plugin.Instance.Configuration.OriginalTitlePreference, preferredMetadataLangauge)?.Name;
+
+        // The original title is the Japanese one, that being the language the anime was made
+        // in, written in romaji rather than in kanji: it is the name the show is catalogued
+        // under outside Japan, and it reads to anyone, which the kanji does not. It does not
+        // follow the displayed title's language.
+        string? originalTitle = titles.Localize(TitlePreferenceType.JapaneseRomaji, preferredMetadataLangauge)?.Name;
 
         return (title, originalTitle);
     }

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -31,6 +31,12 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 /// </summary>
 public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, SeriesInfo>, IHasOrder
 {
+    /// <summary>
+    /// The rating given to anime AniDB flags as adult, so that Jellyfin's parental controls
+    /// have something to act on.
+    /// </summary>
+    private const string AdultOfficialRating = "XXX";
+
     // AniDB bans a client that sends requests closer together than 2500ms, which is the
     // floor the configured interval is clamped to. A bucket limiter cannot express this: it
     // replenishes independently of when tokens are consumed, so an idle plugin holding a full
@@ -65,7 +71,173 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     private static readonly TimeSpan _maximumBanBackoff = TimeSpan.FromHours(24);
     private static readonly Lock _banLock = new();
 
-    private static readonly int[] IgnoredTagIds = [6, 22, 23, 60, 128, 129, 185, 216, 242, 255, 268, 269, 289];
+    /// <summary>
+    /// AniDB tags that are dropped before anything else looks at them, matched on the tag's own
+    /// id and on its parent id, so listing a branch also removes the tags directly under it.
+    /// </summary>
+    private static readonly int[] IgnoredTagIds =
+    [
+        // Maintenance tags. AniDB housekeeping that says nothing about the show.
+        3955,   // DESCRIPTION MISSING (1610)
+        5939,   // CAST MISSING (2042)
+        6850,   // STAFF MISSING (335)
+
+        // Origin. On more than 14000 anime between them, so they distinguish nothing.
+        6173,   // origin
+        6152,   // Chinese production (1471)
+        6166,   // South Korean production (288)
+        7885,   // Japanese production (14413)
+    ];
+
+    /// <summary>
+    /// The tags AniDB flags as 18+ content, dropped unless
+    /// <see cref="PluginConfiguration.IncludeAdultTags"/> says otherwise. Matched on the tag's
+    /// own id and on its parent id, so listing a branch also removes the tags under it. Kept
+    /// apart from <see cref="IgnoredTagIds"/> because whether these belong in a library is the
+    /// owner's call. Yuri and pornography are flagged by AniDB but left in, because
+    /// <see cref="GenreHelper"/> reads both as genres. The counts are the anime carrying each
+    /// tag when the list was taken.
+    /// </summary>
+    private static readonly int[] AdultTagIds =
+    [
+        301,    // lactation (169)
+        724,    // shotacon (0)
+        1172,   // sex slave (0)
+        1521,   // anal tail (0)
+        2016,   // inverted nipples (0)
+        2142,   // pubic hair (0)
+        2429,   // futanari (107)
+        2693,   // handjob (405)
+        2694,   // glory hole (6)
+        2696,   // threesome (497)
+        2698,   // pantyjob (101)
+        2699,   // sixty-nine (358)
+        2700,   // window fuck (94)
+        2701,   // pussy sandwich (83)
+        2702,   // boobjob (602)
+        2703,   // wakamezake (6)
+        2704,   // cum play (208)
+        2705,   // creampie (967)
+        2706,   // masturbation (715)
+        2707,   // internal shots (551)
+        2708,   // uncensored version available (594)
+        2709,   // netorare (203)
+        2710,   // squirting (253)
+        2711,   // urination (458)
+        2714,   // point of view (38)
+        2715,   // rape (835)
+        2717,   // anal (710)
+        2719,   // gang bang (363)
+        2720,   // bestiality (64)
+        2721,   // public sex (578)
+        2722,   // doggy style (840)
+        2724,   // double penetration (412)
+        2725,   // ahegao (242)
+        2726,   // prostitution (233)
+        2727,   // stomach stretch (100)
+        2728,   // fisting (36)
+        2730,   // exhibitionism (169)
+        2731,   // sex while on the phone (61)
+        2732,   // female rapes female (145)
+        2733,   // enjoyable rape (337)
+        2734,   // scissoring (67)
+        2736,   // mother-daughter incest (34)
+        2737,   // father-daughter incest (47)
+        2740,   // mother-son incest (57)
+        2742,   // futa x futa (16)
+        2743,   // futa x male (22)
+        2744,   // futa x female (88)
+        2747,   // hidden vibrator (101)
+        2828,   // borderline porn (188)
+        2842,   // incest (441)
+        2896,   // deflowering (697)
+        2899,   // strap-on dildo (113)
+        2900,   // dildos - vibrators (465)
+        2902,   // facesitting (90)
+        2903,   // scat (63)
+        2911,   // footjob (122)
+        2912,   // shimaidon (86)
+        2913,   // cum swapping (18)
+        2914,   // bukkake (128)
+        2918,   // cunnilingus (808)
+        2920,   // rimming (186)
+        2921,   // throat fucking (362)
+        2935,   // stomach bulge (97)
+        2995,   // nipple penetration (21)
+        3299,   // double fellatio (158)
+        3443,   // orgy (150)
+        3800,   // oyakodon (45)
+        4020,   // pegging (13)
+        4046,   // foursome (177)
+        4049,   // outdoor sex (405)
+        4207,   // doujin (22)
+        4492,   // gang rape (243)
+        4594,   // acidic breast milk (0)
+        4741,   // anal pissing (10)
+        5053,   // vagina dentata (0)
+        5327,   // urophagia (32)
+        5451,   // soapland (11)
+        5715,   // eye penetration (4)
+        5750,   // triple penetration (118)
+        6164,   // onahole (11)
+        6218,   // gokkun (252)
+        6221,   // cybersex (13)
+        6268,   // fellatio (1165)
+        6355,   // water sex (120)
+        6389,   // cervix penetration (60)
+        6443,   // wooden horse (34)
+        6455,   // double-sided dildo (59)
+        6507,   // pillory (8)
+        6519,   // autofellatio (6)
+        6520,   // foreskin sex (2)
+        6538,   // large areolae (0)
+        6572,   // FFM threesome (342)
+        6573,   // MMF threesome (120)
+        6731,   // wax play (38)
+        6829,   // sleeping sex (30)
+        6843,   // MMM threesome (8)
+        7004,   // prostate massage (56)
+        7148,   // impregnation with larvae (32)
+        7151,   // pregnant with larvae (0)
+        7229,   // fingering (410)
+        7247,   // sumata (83)
+        7251,   // cockring (18)
+        7399,   // orgasm denial (24)
+        7403,   // anal fingering (107)
+        7420,   // spitroast (77)
+        7422,   // reverse spitroast (63)
+        7560,   // suspension bondage (65)
+        7600,   // macrophilia (27)
+        7614,   // double assjob (3)
+        7615,   // assjob (13)
+        7633,   // petplay (17)
+        7829,   // FFF threesome (36)
+        7868,   // microphilia (4)
+        7886,   // wormhole sex (3)
+        7957,   // group sex (0)
+        7958,   // stripper (0)
+        8013,   // vaginal pissing (2)
+        8028,   // pasties (0)
+        8038,   // nipple stimulation (260)
+        8163,   // internal breast shots (3)
+        8266,   // double vaginal penetration (2)
+        8267,   // double anal penetration (0)
+        8268,   // biphallic (3)
+
+        // Branches AniDB leaves unflagged that explicit tags are filed under, matched as
+        // parent ids to clear those out.
+        1773,   // tentacle (335)
+        1894,   // shota (136)
+        2566,   // loli (394)
+        2608,   // fetishes (0)
+        2697,   // voyeurism (285)
+        2712,   // sex toys (276)
+        2729,   // BDSM (652)
+        2816,   // sexual fantasies (336)
+        2891,   // breasts (0)
+        2901,   // bondage (524)
+    ];
+
     private static readonly CompositeFormat _seriesQueryUrlFormat = CompositeFormat.Parse("http://api.anidb.net:9001/httpapi?request=anime&client={0}&clientver=1&protover=1&aid={1}");
 
     /// <summary>
@@ -587,6 +759,11 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         {
             await reader.MoveToContentAsync().ConfigureAwait(false);
 
+            if (string.Equals(reader.GetAttribute("restricted"), "true", StringComparison.OrdinalIgnoreCase))
+            {
+                series.OfficialRating = AdultOfficialRating;
+            }
+
             while (await reader.ReadAsync().ConfigureAwait(false))
             {
                 if (reader.NodeType == XmlNodeType.Element)
@@ -715,11 +892,6 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         {
             if (reader.NodeType == XmlNodeType.Element && reader.Name == "episode")
             {
-                if (int.TryParse(reader.GetAttribute("id"), out int id) && IgnoredTagIds.Contains(id))
-                {
-                    continue;
-                }
-
                 using var episodeSubtree = reader.ReadSubtree();
                 while (await episodeSubtree.ReadAsync().ConfigureAwait(false))
                 {
@@ -736,8 +908,20 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         }
     }
 
+    private static bool IsIgnoredTag(int tagId)
+    {
+        if (IgnoredTagIds.Contains(tagId))
+        {
+            return true;
+        }
+
+        return !Plugin.Instance.Configuration.IncludeAdultTags && AdultTagIds.Contains(tagId);
+    }
+
     private static async Task ParseTags(Series series, XmlReader reader)
     {
+        var configuration = Plugin.Instance.Configuration;
+        var blacklist = GetTagBlacklist(configuration.TagBlacklist);
         var genres = new List<GenreInfo>();
 
         while (await reader.ReadAsync().ConfigureAwait(false))
@@ -749,13 +933,17 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                     weight = 0;
                 }
 
-                if (int.TryParse(reader.GetAttribute("id"), out int id) && IgnoredTagIds.Contains(id))
+                // AniDB marks the tags it shows in the infobox on the anime's page. Read
+                // before the subtree, which moves off the element the attributes are on.
+                var infobox = string.Equals(reader.GetAttribute("infobox"), "true", StringComparison.OrdinalIgnoreCase);
+
+                if (int.TryParse(reader.GetAttribute("id"), CultureInfo.InvariantCulture, out int id) && IsIgnoredTag(id))
                 {
                     continue;
                 }
 
-                if (int.TryParse(reader.GetAttribute("parentid"), out int parentId)
-                    && IgnoredTagIds.Contains(parentId))
+                if (int.TryParse(reader.GetAttribute("parentid"), CultureInfo.InvariantCulture, out int parentId)
+                    && IsIgnoredTag(parentId))
                 {
                     continue;
                 }
@@ -766,12 +954,17 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                     if (tagSubtree.NodeType == XmlNodeType.Element && tagSubtree.Name == "name")
                     {
                         var name = await tagSubtree.ReadElementContentAsStringAsync().ConfigureAwait(false);
-                        if (name == "18 restricted")
+
+                        // Decided before any filter: the rating is what parental controls act
+                        // on, and it must not depend on how the tag list was narrowed.
+                        if (string.Equals(name, "18 restricted", StringComparison.OrdinalIgnoreCase))
                         {
-                            series.OfficialRating = "XXX";
+                            series.OfficialRating = AdultOfficialRating;
                         }
 
-                        if (weight >= 400)
+                        if (weight >= configuration.MinimumTagWeight
+                            && (infobox || !configuration.InfoboxTagsOnly)
+                            && !blacklist.Contains(name))
                         {
                             genres.Add(new GenreInfo { Name = name, Weight = weight });
                         }
@@ -780,7 +973,28 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
             }
         }
 
-        series.Genres = [.. genres.OrderBy(g => g.Weight).Select(g => g.Name)];
+        // Descending: the list is later trimmed to the first MaxGenres entries, which must
+        // be the ones AniDB weighted highest.
+        var ordered = genres.OrderByDescending(g => g.Weight).Select(g => g.Name).ToArray();
+
+        series.Genres = ordered;
+
+        // Every tag that got this far is kept as a tag, whether or not it also names a
+        // genre. Which of them become genres is GenreHelper's business, and a tag list
+        // assembled there would vanish whenever genres were turned off.
+        series.Tags = [.. series.Tags.Concat(ordered).Distinct(StringComparer.OrdinalIgnoreCase)];
+    }
+
+    private static HashSet<string> GetTagBlacklist(string value)
+    {
+        var blacklist = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var name in value.Split([',', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            blacklist.Add(name);
+        }
+
+        return blacklist;
     }
 
     private static async Task ParseResources(Series series, XmlReader reader)

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -598,9 +598,11 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
 
                             if (!string.IsNullOrWhiteSpace(val))
                             {
-                                if (DateTime.TryParse(val, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out DateTime date))
+                                // AniDB reports a calendar date with no time and no zone.
+                                // AssumeUniversal keeps it as written rather than reading it
+                                // as the server's local time and shifting it by that offset.
+                                if (DateTime.TryParse(val, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTime date))
                                 {
-                                    date = date.ToUniversalTime();
                                     series.PremiereDate = date;
                                 }
                             }
@@ -612,9 +614,11 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
 
                             if (!string.IsNullOrWhiteSpace(endDate))
                             {
-                                if (DateTime.TryParse(endDate, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out DateTime date))
+                                // AniDB reports a calendar date with no time and no zone.
+                                // AssumeUniversal keeps it as written rather than reading it
+                                // as the server's local time and shifting it by that offset.
+                                if (DateTime.TryParse(endDate, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTime date))
                                 {
-                                    date = date.ToUniversalTime();
                                     series.EndDate = date;
                                 }
                             }
@@ -724,12 +728,6 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                         switch (episodeSubtree.Name)
                         {
                             case "epno":
-                                // var epno = episodeSubtree.ReadElementContentAsString();
-                                // EpisodeInfo info = new EpisodeInfo();
-                                // info.AnimeSeriesIndex = series.AnimeSeriesIndex;
-                                // info.IndexNumberEnd = string(epno);
-                                // info.SeriesProviderIds.GetValueOrDefault(ProviderNames.AniDb);
-                                // episodes.Add(info);
                                 break;
                         }
                     }
@@ -746,7 +744,7 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         {
             if (reader.NodeType == XmlNodeType.Element && reader.Name == "tag")
             {
-                if (!int.TryParse(reader.GetAttribute("weight"), out int weight))
+                if (!int.TryParse(reader.GetAttribute("weight"), CultureInfo.InvariantCulture, out int weight))
                 {
                     weight = 0;
                 }
@@ -991,9 +989,8 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         text = text.Replace("&#x0;", string.Empty, StringComparison.Ordinal);
 
         // Validate before touching the cache. AniDB answers a ban with an <error> document,
-        // and the daily quota is low, so overwriting good cached data with an error would
-        // force another request on the very next scan - precisely when no request must be
-        // made. On failure the previous cache is left intact.
+        // and overwriting good cached data with one would force another request on the next
+        // scan, exactly when none must be made.
         var errorRegexMatch = ErrorRegex().Match(text);
         if (errorRegexMatch.Success)
         {
@@ -1049,7 +1046,7 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         }
         catch (DirectoryNotFoundException)
         {
-            // No biggie
+            // Nothing cached to remove.
         }
     }
 
@@ -1065,11 +1062,9 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         };
 
         using var streamReader = new StreamReader(seriesDataPath, Encoding.UTF8);
-        // Use XmlReader for best performance
         using var reader = XmlReader.Create(streamReader, settings);
         await reader.MoveToContentAsync().ConfigureAwait(false);
 
-        // Loop through each element
         while (await reader.ReadAsync().ConfigureAwait(false))
         {
             if (reader.NodeType == XmlNodeType.Element)
@@ -1098,11 +1093,9 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
 
         using (var streamReader = new StreamReader(seriesDataPath, Encoding.UTF8))
         {
-            // Use XmlReader for best performance
             using var reader = XmlReader.Create(streamReader, settings);
             await reader.MoveToContentAsync().ConfigureAwait(false);
 
-            // Loop through each element
             while (await reader.ReadAsync().ConfigureAwait(false))
             {
                 if (reader.NodeType == XmlNodeType.Element && reader.Name == "characters")
@@ -1138,12 +1131,18 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
             {
                 try
                 {
-                    using var stream = File.Open(path, FileMode.Create);
-                    serializer.Serialize(stream, person);
+                    var partialPath = path + ".partial";
+
+                    using (var stream = File.Open(partialPath, FileMode.Create))
+                    {
+                        serializer.Serialize(stream, person);
+                    }
+
+                    File.Move(partialPath, path, true);
                 }
                 catch (IOException)
                 {
-                    // ignore
+                    // Another refresh is writing the same person; either copy will do.
                 }
             }
         }
@@ -1157,6 +1156,13 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     /// <returns>The cached person info, or <c>null</c> when it is not cached.</returns>
     public static AniDbPersonInfo? GetPersonInfo(string cachePath, string name)
     {
+        // The cache files a person under the first character of their name, so a blank one
+        // has nowhere to be looked up.
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+
         var path = GetCastPath(name, cachePath);
         var serializer = new XmlSerializer(typeof(AniDbPersonInfo));
 
@@ -1177,6 +1183,24 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         }
         catch (IOException)
         {
+            return null;
+        }
+        catch (InvalidOperationException ex)
+        {
+            // What XmlSerializer throws for a document it cannot read. The file is only
+            // rewritten for a person who turns up again with an image, so leaving it would
+            // fail this person on every refresh. Removing it means simply not cached.
+            Logger?.LogWarning(ex, "Discarding the unreadable cached person file {Path}", path);
+
+            try
+            {
+                File.Delete(path);
+            }
+            catch (Exception deleteException) when (deleteException is IOException or UnauthorizedAccessException)
+            {
+                // The next refresh tries again.
+            }
+
             return null;
         }
 
@@ -1269,8 +1293,18 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
             Async = true
         };
 
-        using var writer = XmlWriter.Create(filename, writerSettings);
-        await writer.WriteRawAsync(xml).ConfigureAwait(false);
+        // Written beside the real file and moved onto it once complete. A crash or a full disk
+        // part way through a direct write would leave a truncated document, which is worse than
+        // none: it does not look stale, so every read of it fails until the cache window lapses.
+        var partialFilename = filename + ".partial";
+
+        using (var writer = XmlWriter.Create(partialFilename, writerSettings))
+        {
+            await writer.WriteRawAsync(xml).ConfigureAwait(false);
+            await writer.FlushAsync().ConfigureAwait(false);
+        }
+
+        File.Move(partialFilename, filename, true);
     }
 
     private static async Task SaveEpsiodeXml(string seriesDataDirectory, string xml)
@@ -1296,11 +1330,9 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         };
 
         using var streamReader = new StringReader(xml);
-        // Use XmlReader for best performance
         using var reader = XmlReader.Create(streamReader, settings);
         await reader.MoveToContentAsync().ConfigureAwait(false);
 
-        // Loop through each element
         while (await reader.ReadAsync().ConfigureAwait(false))
         {
             if (reader.NodeType == XmlNodeType.Element)

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -285,6 +285,15 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     /// </summary>
     private static bool _resumeLogged;
 
+    /// <summary>
+    /// How many callers are waiting for a request slot, how many requests have gone out since
+    /// the server started, and when the last one did. Reported by <see cref="GetRequestStatus"/>
+    /// and touched only through <see cref="Interlocked"/>.
+    /// </summary>
+    private static int _queuedRequests;
+    private static long _requestsSent;
+    private static long _lastRequestTicks;
+
     private readonly IApplicationPaths _appPaths;
 
     /// <summary>
@@ -672,26 +681,57 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     {
         ThrowIfBanned();
 
-        // The gate is held across the wait so that concurrent callers queue behind each
-        // other rather than all sleeping in parallel and then firing at the same moment.
-        await _requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        Interlocked.Increment(ref _queuedRequests);
+
         try
         {
-            // Task.Delay may fire fractionally early, so re-check the interval.
-            for (var remaining = GetRemainingInterval(); remaining > TimeSpan.Zero; remaining = GetRemainingInterval())
+            // The gate is held across the wait so that concurrent callers queue behind each
+            // other rather than all sleeping in parallel and then firing at the same moment.
+            await _requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
             {
-                await Task.Delay(remaining < _minimumDelay ? _minimumDelay : remaining, cancellationToken).ConfigureAwait(false);
+                // Task.Delay may fire fractionally early, so re-check the interval.
+                for (var remaining = GetRemainingInterval(); remaining > TimeSpan.Zero; remaining = GetRemainingInterval())
+                {
+                    await Task.Delay(remaining < _minimumDelay ? _minimumDelay : remaining, cancellationToken).ConfigureAwait(false);
+                }
+
+                // A caller ahead in the queue may have been banned while this one waited.
+                ThrowIfBanned();
+
+                _nextRequestTimestamp = Stopwatch.GetTimestamp() + GetRequestIntervalTicks();
+
+                Interlocked.Increment(ref _requestsSent);
+                Interlocked.Exchange(ref _lastRequestTicks, DateTime.UtcNow.Ticks);
             }
-
-            // A caller ahead in the queue may have been banned while this one waited.
-            ThrowIfBanned();
-
-            _nextRequestTimestamp = Stopwatch.GetTimestamp() + GetRequestIntervalTicks();
+            finally
+            {
+                _requestGate.Release();
+            }
         }
         finally
         {
-            _requestGate.Release();
+            Interlocked.Decrement(ref _queuedRequests);
         }
+    }
+
+    /// <summary>
+    /// How the plugin currently stands with AniDB, for the status the configuration page
+    /// shows. A scan that looks stalled is almost always one queued behind the rate limit or
+    /// waiting out a ban, and neither is visible from the library screen.
+    /// </summary>
+    /// <returns>What is left of any ban, how many requests are waiting for a slot, how long until the next may be sent, how many have been sent since the server started, and when the last one went out.</returns>
+    internal static (TimeSpan BanRemaining, int Queued, TimeSpan UntilNextRequest, long Sent, DateTime? LastSentUtc) GetRequestStatus()
+    {
+        var lastTicks = Interlocked.Read(ref _lastRequestTicks);
+        var untilNext = GetRemainingInterval();
+
+        return (
+            GetRemainingBanTime(),
+            Volatile.Read(ref _queuedRequests),
+            untilNext > TimeSpan.Zero ? untilNext : TimeSpan.Zero,
+            Interlocked.Read(ref _requestsSent),
+            lastTicks == 0 ? null : new DateTime(lastTicks, DateTimeKind.Utc));
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -16,6 +16,7 @@ using System.Xml.Serialization;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.AniDB.Configuration;
 using Jellyfin.Plugin.AniDB.Providers.AniDB.Identity;
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
@@ -23,6 +24,7 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 
@@ -41,6 +43,14 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     /// Where AniDB serves the pictures it names in a picture attribute.
     /// </summary>
     private const string PersonImageBaseUrl = "https://cdn.anidb.net/images/main/";
+
+    /// <summary>
+    /// How many name matches an identify offers. Each one costs an AniDB request, paced
+    /// seconds apart, and the fuzzy search behind them returns every show whose name merely
+    /// begins alike - 78 of them for "Oshi no Ko". Without a cap one identify of a commonly
+    /// named show spends dozens of requests and is enough on its own to earn a ban.
+    /// </summary>
+    private const int MaxSearchResults = 10;
 
     // AniDB bans a client that sends requests closer together than 2500ms, which is the
     // floor the configured interval is clamped to. A bucket limiter cannot express this: it
@@ -327,9 +337,9 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     {
         var animeId = info.ProviderIds.GetValueOrDefault(ProviderNames.AniDb);
 
-        if (string.IsNullOrEmpty(animeId) && !string.IsNullOrEmpty(info.Name))
+        if (string.IsNullOrEmpty(animeId))
         {
-            animeId = await Equals_check.XmlFindId(info.Name, cancellationToken).ConfigureAwait(false);
+            animeId = await Identify(info, cancellationToken).ConfigureAwait(false);
         }
 
         if (!string.IsNullOrEmpty(animeId))
@@ -338,6 +348,123 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         }
 
         return new MetadataResult<Series>();
+    }
+
+    /// <summary>
+    /// Works out which AniDB entry a show is, from whatever the library already knows of it.
+    /// </summary>
+    /// <param name="info">The series lookup info.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The AniDB id, or <c>null</c> when the show cannot be identified.</returns>
+    private async Task<string?> Identify(SeriesInfo info, CancellationToken cancellationToken)
+    {
+        // A TVDB or TMDB id a provider ahead of this one has already settled on names the show
+        // outright, and the mapping sources record which AniDB entry that id is. It is tried
+        // first because a name is the weaker evidence of the two: AniDB spells a great many
+        // names differently from TVDB, and where two shows do share a name the id is the only
+        // thing that tells them apart. A folder naming a season is left to the name match
+        // below, because the id names the whole show and would answer with its first season.
+        if (!AniDbSeasonResolver.NamesASeason(info.Name))
+        {
+            var mapped = await AniDbMappings.ResolveSeriesId(
+                _appPaths,
+                info.ProviderIds.GetValueOrDefault(nameof(MetadataProvider.Tvdb)),
+                info.ProviderIds.GetValueOrDefault(nameof(MetadataProvider.Tmdb)),
+                Logger ?? (ILogger)NullLogger.Instance,
+                cancellationToken).ConfigureAwait(false);
+
+            if (mapped != null)
+            {
+                Logger?.LogInformation(
+                    "{SeriesName} is AniDB anime {AnimeId}, which {Source} files under {Provider} series {ProviderId}",
+                    info.Name,
+                    mapped.AnimeId,
+                    mapped.Source,
+                    mapped.Provider,
+                    mapped.ProviderId);
+
+                return mapped.AnimeId;
+            }
+        }
+
+        // The folder is what the user named, and it still says which show this is where the name
+        // on the item no longer does.
+        var folderName = Path.GetFileName(info.Path?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        var truncated = IsTruncation(info.Name, folderName);
+
+        if (truncated)
+        {
+            Logger?.LogInformation(
+                "{SeriesName} is what is left of the folder name {FolderName} once it was cut short, so the folder is searched instead. A name with no letters in it matches almost any anime, this search being a fuzzy one, and matching the wrong one would settle the show for good",
+                info.Name,
+                folderName);
+        }
+
+        var matched = string.IsNullOrEmpty(info.Name) || truncated
+            ? string.Empty
+            : await Equals_check.XmlFindId(info.Name, GetLookupYear(info), cancellationToken).ConfigureAwait(false);
+
+        // The name searched above is the item's, which is whatever provider reached it first,
+        // and a provider that matched the wrong show has already renamed it to that show. The
+        // folder gets an attempt of its own, under the year written into it rather than the
+        // wrong show's.
+        if (string.IsNullOrEmpty(matched)
+            && !string.IsNullOrEmpty(folderName)
+            && !string.Equals(folderName, info.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            matched = await Equals_check.XmlFindId(folderName, YearInName(folderName) ?? GetLookupYear(info), cancellationToken).ConfigureAwait(false);
+
+            if (!string.IsNullOrEmpty(matched))
+            {
+                Logger?.LogInformation(
+                    "{SeriesName} could not be matched under that name, but its folder {FolderName} is AniDB anime {AnimeId}. The name on the item is another provider's, and that provider matched a different show",
+                    info.Name,
+                    folderName,
+                    matched);
+            }
+        }
+
+        if (string.IsNullOrEmpty(matched))
+        {
+            Logger?.LogInformation(
+                "No AniDB entry could be identified for {SeriesName} (folder {FolderName}). Where two shows share a name, the year in the folder name is what tells them apart, and a TVDB id on the show lets the anime list answer instead",
+                info.Name,
+                folderName);
+
+            return null;
+        }
+
+        // Only a name match is walked back. An id set by hand names the entry to use, the
+        // TVDB route already answers with the show's first entry, and the season provider asks
+        // for a season's own entry by id.
+        var searchedName = info.Name ?? folderName;
+
+        // The list is asked before AniDB's own relations are walked. A name match lands on a
+        // later season more often than it looks: AniDB disambiguates a second season by
+        // appending its year, exactly as it does a remake, so a show whose seasons all aired in
+        // one year matches its own sequel. The list records which season every entry fills, so
+        // it settles this for nothing, where each hop of the relation walk costs a request.
+        if (!AniDbSeasonResolver.NamesASeason(searchedName))
+        {
+            var listedFirst = await AniDbMappings.ResolveFirstSeason(
+                _appPaths,
+                matched,
+                Logger ?? (ILogger)NullLogger.Instance,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!string.IsNullOrEmpty(listedFirst))
+            {
+                Logger?.LogInformation(
+                    "{SeriesName} matched AniDB anime {MatchedId}, which the mapping sources file as a later season. The show begins at anime {AnimeId}, which is used instead",
+                    searchedName,
+                    matched,
+                    listedFirst);
+
+                return listedFirst;
+            }
+        }
+
+        return await AniDbSeasonResolver.ResolveFirstSeasonId(_appPaths, matched, searchedName, Logger, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -367,55 +494,49 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     public async Task<IEnumerable<RemoteSearchResult>> GetSearchResults(SeriesInfo searchInfo, CancellationToken cancellationToken)
     {
         var results = new List<RemoteSearchResult>();
-        var animeId = searchInfo.ProviderIds.GetValueOrDefault(ProviderNames.AniDb);
+        var offered = new HashSet<string>(StringComparer.Ordinal);
+        var imageProvider = new AniDbImageProvider(_appPaths);
 
-        if (!string.IsNullOrEmpty(animeId))
+        async Task Offer(string? id)
         {
-            var resultMetadata = await GetMetadataForId(animeId, searchInfo, cancellationToken).ConfigureAwait(false);
-
-            if (resultMetadata.HasMetadata)
+            if (string.IsNullOrEmpty(id) || !offered.Add(id))
             {
-                var imageProvider = new AniDbImageProvider(_appPaths);
-                var images = await imageProvider.GetImages(animeId, cancellationToken).ConfigureAwait(false);
-                results.Add(MetadataToRemoteSearchResult(resultMetadata, images));
+                return;
+            }
+
+            var metadata = await GetMetadataForId(id, searchInfo, cancellationToken).ConfigureAwait(false);
+
+            if (metadata.HasMetadata)
+            {
+                // Read from the document the line above has just cached, so this costs no
+                // request of its own.
+                var images = await imageProvider.GetImages(id, cancellationToken).ConfigureAwait(false);
+
+                results.Add(MetadataToRemoteSearchResult(metadata, images));
             }
         }
+
+        await Offer(searchInfo.ProviderIds.GetValueOrDefault(ProviderNames.AniDb)).ConfigureAwait(false);
+
+        // The mapping sources are the ones here that answer with a certainty rather than a
+        // guess, so their answer goes first. They also settle the question the name cannot: they
+        // hold anime only, so an id they do not carry belongs to something that is not an
+        // anime - a live action adaptation sharing the show's name, most often - and an id they
+        // do carry names the AniDB entry outright.
+        var mapped = await AniDbMappings.ResolveSeriesId(
+            _appPaths,
+            searchInfo.ProviderIds.GetValueOrDefault(nameof(MetadataProvider.Tvdb)),
+            searchInfo.ProviderIds.GetValueOrDefault(nameof(MetadataProvider.Tmdb)),
+            Logger ?? (ILogger)NullLogger.Instance,
+            cancellationToken).ConfigureAwait(false);
+
+        await Offer(mapped?.AnimeId).ConfigureAwait(false);
 
         if (!string.IsNullOrEmpty(searchInfo.Name))
         {
-            List<RemoteSearchResult> name_results = await GetSearchResultsByName(searchInfo.Name, searchInfo, cancellationToken).ConfigureAwait(false);
-
-            foreach (var media in name_results)
+            foreach (var id in await Equals_check.XmlSearch(searchInfo.Name, MaxSearchResults, cancellationToken).ConfigureAwait(false))
             {
-                results.Add(media);
-            }
-        }
-
-        return results;
-    }
-
-    /// <summary>
-    /// Searches AniDB for series matching the given name.
-    /// </summary>
-    /// <param name="name">The name to search for.</param>
-    /// <param name="searchInfo">The series lookup info.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The search results.</returns>
-    public async Task<List<RemoteSearchResult>> GetSearchResultsByName(string name, SeriesInfo searchInfo, CancellationToken cancellationToken)
-    {
-        var imageProvider = new AniDbImageProvider(_appPaths);
-        var results = new List<RemoteSearchResult>();
-
-        List<string> ids = await Equals_check.XmlSearch(name, cancellationToken).ConfigureAwait(false);
-
-        foreach (string id in ids)
-        {
-            var resultMetadata = await GetMetadataForId(id, searchInfo, cancellationToken).ConfigureAwait(false);
-
-            if (resultMetadata.HasMetadata)
-            {
-                var images = await imageProvider.GetImages(id, cancellationToken).ConfigureAwait(false);
-                results.Add(MetadataToRemoteSearchResult(resultMetadata, images));
+                await Offer(id).ConfigureAwait(false);
             }
         }
 
@@ -1233,6 +1354,58 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     }
 
     /// <summary>
+    /// The year a lookup should be pinned to, taken from whichever of the item's own year and
+    /// its air date is set.
+    /// </summary>
+    /// <param name="info">The lookup info.</param>
+    /// <returns>The year, or <c>null</c> when nothing gives one.</returns>
+    private static int? GetLookupYear(ItemLookupInfo info)
+        => info.Year ?? info.PremiereDate?.Year;
+
+    /// <summary>
+    /// Whether the name on the item is the folder name cut short rather than a name of its own.
+    /// </summary>
+    /// <remarks>
+    /// A show whose name begins with a number and a dot arrives here named with just that
+    /// number: "2.43: Seiin High School Boys Volleyball Team" in a folder of that name reaches
+    /// this as "2". Whatever cut it is not this plugin - nothing here reads a name apart at a
+    /// dot - but searching what is left would match almost any anime, the search being fuzzy and
+    /// a single digit appearing in thousands of titles, and a match however wrong would keep the
+    /// folder from being tried at all. A name with no letter anywhere in it is the mark of such
+    /// a cut: a real title of that shape - "009-1", "001", "663114" - is its folder's name
+    /// whole rather than the start of it.
+    /// </remarks>
+    /// <param name="name">The name on the item.</param>
+    /// <param name="folderName">The name of the folder holding it.</param>
+    /// <returns><c>true</c> where the name is the folder name cut short.</returns>
+    private static bool IsTruncation(string? name, string? folderName)
+    {
+        if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(folderName) || name.Any(char.IsLetter))
+        {
+            return false;
+        }
+
+        return folderName.Length > name.Length
+            && folderName.StartsWith(name, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The year a folder name carries, as "Ranma &#189; (1989)" does. It is what tells two
+    /// shows of one name apart, and it belongs to the folder rather than to whatever the item
+    /// has since been named.
+    /// </summary>
+    /// <param name="name">The folder name.</param>
+    /// <returns>The year, or <c>null</c> when the name carries none.</returns>
+    private static int? YearInName(string name)
+    {
+        var match = TrailingYearRegex().Match(name);
+
+        return match.Success && int.TryParse(match.Groups[1].ValueSpan, CultureInfo.InvariantCulture, out var year)
+            ? year
+            : null;
+    }
+
+    /// <summary>
     /// Reverses the order of the parts of a name.
     /// </summary>
     /// <param name="name">The name to reverse.</param>
@@ -1650,6 +1823,9 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
 
     [GeneratedRegex("banned", RegexOptions.IgnoreCase)]
     private static partial Regex BannedRegex();
+
+    [GeneratedRegex(@"\(([0-9]{4})\)\s*$", RegexOptions.CultureInvariant)]
+    private static partial Regex TrailingYearRegex();
 
     private struct GenreInfo
     {

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -37,6 +37,11 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     /// </summary>
     private const string AdultOfficialRating = "XXX";
 
+    /// <summary>
+    /// Where AniDB serves the pictures it names in a picture attribute.
+    /// </summary>
+    private const string PersonImageBaseUrl = "https://cdn.anidb.net/images/main/";
+
     // AniDB bans a client that sends requests closer together than 2500ms, which is the
     // floor the configured interval is clamped to. A bucket limiter cannot express this: it
     // replenishes independently of when tokens are consumed, so an idle plugin holding a full
@@ -272,11 +277,26 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
 
     private readonly IApplicationPaths _appPaths;
 
-    private readonly Dictionary<string, PersonKind> _typeMappings = new()
+    /// <summary>
+    /// What AniDB's creator types mean to Jellyfin. The role is what the cast list shows
+    /// under the name, so it keeps AniDB's own wording where Jellyfin has no kind for it.
+    /// </summary>
+    private static readonly Dictionary<string, (PersonKind Kind, string Role)> _creatorTypes = new(StringComparer.OrdinalIgnoreCase)
     {
-        { "Direction", PersonKind.Director },
-        { "Music", PersonKind.Composer },
-        { "Chief Animation Direction", PersonKind.Director }
+        { "Direction", (PersonKind.Director, "Director") },
+        { "Chief Direction", (PersonKind.Director, "Chief Director") },
+        { "Series Direction", (PersonKind.Director, "Series Director") },
+        { "Animation Direction", (PersonKind.Director, "Animation Director") },
+        { "Chief Animation Direction", (PersonKind.Director, "Chief Animation Director") },
+        { "Music", (PersonKind.Composer, "Music") },
+        { "Original Work", (PersonKind.Writer, "Original Creator") },
+        { "Story Composition", (PersonKind.Writer, "Story Composition") },
+        { "Series Composition", (PersonKind.Writer, "Series Composition") },
+        { "Screenplay", (PersonKind.Writer, "Screenplay") },
+        { "Original Plan", (PersonKind.Writer, "Original Plan") },
+        { "Character Design", (PersonKind.Artist, "Character Design") },
+        { "Main Character Design", (PersonKind.Artist, "Main Character Design") },
+        { "Animation Character Design", (PersonKind.Artist, "Animation Character Design") }
     };
 
     /// <summary>
@@ -1037,7 +1057,7 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         return text.Replace("\n", "<br>", StringComparison.Ordinal);
     }
 
-    private async Task ParseActors(MetadataResult<Series> series, XmlReader reader)
+    private static async Task ParseActors(MetadataResult<Series> series, XmlReader reader)
     {
         while (await reader.ReadAsync().ConfigureAwait(false))
         {
@@ -1052,10 +1072,12 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         }
     }
 
-    private async Task ParseActor(MetadataResult<Series> series, XmlReader reader)
+    private static async Task ParseActor(MetadataResult<Series> series, XmlReader reader)
     {
         string? name = null;
         string? role = null;
+        string? picture = null;
+        string? personId = null;
 
         while (await reader.ReadAsync().ConfigureAwait(false))
         {
@@ -1068,18 +1090,23 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                         break;
 
                     case "seiyuu":
+                        // Read before the content, which moves off the element these are on.
+                        picture = reader.GetAttribute("picture");
+                        personId = reader.GetAttribute("id");
                         name = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
                         break;
                 }
             }
         }
 
-        if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(role)) // && series.People.All(p => p.Name != name))
+        if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(role))
         {
             series.AddPerson(CreatePerson(
                 Plugin.Instance.Configuration.AniDbReplaceGraves ? name.Replace('`', '\'') : name,
-                PersonType.Actor,
-                role));
+                PersonKind.Actor,
+                role,
+                GetPersonImageUrl(picture),
+                personId));
         }
     }
 
@@ -1131,13 +1158,14 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         return (title, originalTitle);
     }
 
-    private async Task ParseCreators(MetadataResult<Series> series, XmlReader reader)
+    private static async Task ParseCreators(MetadataResult<Series> series, XmlReader reader)
     {
         while (await reader.ReadAsync().ConfigureAwait(false))
         {
             if (reader.NodeType == XmlNodeType.Element && reader.Name == "name")
             {
                 var type = reader.GetAttribute("type");
+                var personId = reader.GetAttribute("id");
                 var name = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
 
                 if (type == "Animation Work")
@@ -1146,28 +1174,57 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                 }
                 else
                 {
+                    var (kind, role) = GetCreatorRole(type);
+
                     series.AddPerson(CreatePerson(
-                       Plugin.Instance.Configuration.AniDbReplaceGraves ? name.Replace('`', '\'') : name, type));
+                       Plugin.Instance.Configuration.AniDbReplaceGraves ? name.Replace('`', '\'') : name,
+                       kind,
+                       role,
+                       null,
+                       personId));
                 }
             }
         }
     }
 
-    private PersonInfo CreatePerson(string name, string? type, string? role = null)
+    private static (PersonKind Kind, string? Role) GetCreatorRole(string? type)
     {
-        // todo find nationality of person and conditionally reverse name order
-
-        if (!Enum.TryParse(type, out PersonKind personKind))
+        if (string.IsNullOrEmpty(type))
         {
-            personKind = type is null ? PersonKind.Actor : _typeMappings.GetValueOrDefault(type, PersonKind.Actor);
+            return (PersonKind.Unknown, null);
         }
 
-        return new PersonInfo
+        if (_creatorTypes.TryGetValue(type, out var mapped))
+        {
+            return mapped;
+        }
+
+        // Several AniDB types are already the name of a Jellyfin kind.
+        return Enum.TryParse<PersonKind>(type, true, out var parsed)
+            ? (parsed, type)
+            : (PersonKind.Unknown, type);
+    }
+
+    private static string? GetPersonImageUrl(string? picture)
+        => string.IsNullOrEmpty(picture) ? null : PersonImageBaseUrl + picture;
+
+    private static PersonInfo CreatePerson(string name, PersonKind kind, string? role = null, string? imageUrl = null, string? personId = null)
+    {
+        // todo find nationality of person and conditionally reverse name order
+        var person = new PersonInfo
         {
             Name = ReverseNameOrder(name),
-            Type = personKind,
-            Role = role
+            Type = kind,
+            Role = role,
+            ImageUrl = imageUrl
         };
+
+        if (!string.IsNullOrEmpty(personId))
+        {
+            person.ProviderIds[ProviderNames.AniDb] = personId;
+        }
+
+        return person;
     }
 
     /// <summary>
@@ -1448,7 +1505,7 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                     var picture = seiyuu.Attribute("picture");
                     if (picture != null && !string.IsNullOrEmpty(picture.Value))
                     {
-                        person.Image = "https://cdn.anidb.net/images/main/" + picture.Value;
+                        person.Image = PersonImageBaseUrl + picture.Value;
                     }
 
                     var id = seiyuu.Attribute("id");

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -30,22 +31,36 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 /// </summary>
 public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, SeriesInfo>, IHasOrder
 {
-    // AniDB allows one HTTP API request every 2-4 seconds; sending sequential requests
-    // closer together than 2500ms triggers an automatic ban, so that is the floor here.
-    // Bucket- and window-based limiters cannot express this: they replenish on a fixed
-    // cadence that is independent of when tokens are consumed, so a plugin that has been
-    // idle long enough to hold a full bucket can issue two requests back to back across a
-    // replenishment tick. Gate on the time elapsed since the previous request instead, and
-    // measure it with the monotonic clock so that system time changes cannot shorten it.
-    private static readonly TimeSpan _minimumRequestInterval = TimeSpan.FromMilliseconds(2500);
-    private static readonly long _minimumRequestIntervalTicks = (long)(Stopwatch.Frequency * _minimumRequestInterval.TotalSeconds);
+    // AniDB bans a client that sends requests closer together than 2500ms, which is the
+    // floor the configured interval is clamped to. A bucket limiter cannot express this: it
+    // replenishes independently of when tokens are consumed, so an idle plugin holding a full
+    // bucket can fire two requests back to back. Gate on the time since the previous request
+    // instead, measured with the monotonic clock so a system time change cannot shorten it.
     private static readonly TimeSpan _minimumDelay = TimeSpan.FromMilliseconds(1);
     private static readonly SemaphoreSlim _requestGate = new(1, 1);
 
-    // An AniDB ban is temporary but its remaining time cannot be queried, and reported
-    // durations range from 15 minutes to 24 hours depending on how badly the limit was
-    // exceeded. Repeatedly probing a banned server extends the ban, so back off for
-    // twice as long after each consecutive ban and reset once a request succeeds.
+    /// <summary>
+    /// How long an id AniDB has refused is left alone before it is asked for again. Long
+    /// enough that a scan does not keep paying for the same refusal, short enough that an
+    /// entry restored on AniDB's side is picked up the same day.
+    /// </summary>
+    private static readonly TimeSpan _retryAfterRefusal = TimeSpan.FromHours(6);
+
+    /// <summary>
+    /// One gate per anime, so that the episodes of a season refreshing together send one
+    /// request for the entry they share rather than one apiece.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> _downloadGates = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The ids AniDB has refused, and what it said. Kept because a refusal caches nothing, so
+    /// without it every episode of the show asks again and pays for the same answer.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, (DateTime At, string Message)> _refusedIds = new(StringComparer.Ordinal);
+
+    // A ban is temporary, but its remaining time cannot be queried and runs from 15 minutes
+    // to 24 hours. Probing a banned server extends the ban, so double the backoff after each
+    // consecutive ban and reset it once a request succeeds.
     private static readonly TimeSpan _initialBanBackoff = TimeSpan.FromMinutes(30);
     private static readonly TimeSpan _maximumBanBackoff = TimeSpan.FromHours(24);
     private static readonly Lock _banLock = new();
@@ -60,9 +75,9 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     private static long _nextRequestTimestamp = Stopwatch.GetTimestamp();
 
     /// <summary>
-    /// The UTC time at which the current ban is assumed to have lapsed. This is wall clock
-    /// rather than the monotonic clock used for request spacing, because a ban outlives the
-    /// process and has to stay meaningful across a restart. Guarded by <see cref="_banLock"/>.
+    /// The UTC time at which the current ban is assumed to have lapsed. Wall clock rather than
+    /// the monotonic clock used for request spacing, because a ban outlives the process.
+    /// Guarded by <see cref="_banLock"/>.
     /// </summary>
     private static DateTime _banUntilUtc = DateTime.MinValue;
 
@@ -78,8 +93,8 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     private static bool _banActive;
 
     /// <summary>
-    /// Whether the "resuming requests" message has already been logged for the current
-    /// ban, so that it is not repeated for every waiting request. Guarded by <see cref="_banLock"/>.
+    /// Whether the "resuming requests" message has already been logged for the current ban.
+    /// Guarded by <see cref="_banLock"/>.
     /// </summary>
     private static bool _resumeLogged;
 
@@ -252,27 +267,87 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     /// <returns>The path to the series data file.</returns>
     public static async Task<string> GetSeriesData(IApplicationPaths appPaths, string seriesId, CancellationToken cancellationToken)
     {
-        var dataPath = GetSeriesDataPath(appPaths, seriesId);
-        var seriesDataPath = Path.Combine(dataPath, "series.xml");
-        var fileInfo = new FileInfo(seriesDataPath);
+        var seriesDataPath = Path.Combine(GetSeriesDataPath(appPaths, seriesId), "series.xml");
 
-        var isEmpty = fileInfo.Exists && fileInfo.Length == 0;
-        var isStale = fileInfo.Exists && DateTime.UtcNow - fileInfo.LastWriteTimeUtc > TimeSpan.FromDays(Plugin.Instance.Configuration.MaxCacheAge);
-
-        if (!fileInfo.Exists || isEmpty || isStale)
+        if (!NeedsDownload(seriesDataPath))
         {
-            // A stale cache entry is still far better than no metadata at all, so while
-            // banned keep reading from disk rather than spending a request that would only
-            // be refused and lengthen the ban.
-            if (fileInfo.Exists && !isEmpty && GetRemainingBanTime() > TimeSpan.Zero)
+            return seriesDataPath;
+        }
+
+        // One download per anime at a time. Every episode of a season asks for the entry it is
+        // read from, and a scan refreshes them together, so without this they all find nothing
+        // cached and send the same request at once - one per episode, for one anime.
+        var gate = _downloadGates.GetOrAdd(seriesId, _ => new SemaphoreSlim(1, 1));
+
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            // Whoever held the gate has very likely just downloaded it.
+            if (!NeedsDownload(seriesDataPath))
             {
                 return seriesDataPath;
             }
 
-            await DownloadSeriesData(seriesId, seriesDataPath, appPaths.CachePath, cancellationToken).ConfigureAwait(false);
+            var fileInfo = new FileInfo(seriesDataPath);
+            var hasCopy = fileInfo.Exists && fileInfo.Length > 0;
+
+            // While banned, read the stale copy rather than spend a request that would only
+            // be refused and lengthen the ban.
+            if (hasCopy && GetRemainingBanTime() > TimeSpan.Zero)
+            {
+                return seriesDataPath;
+            }
+
+            // AniDB refuses some ids outright - one it has deleted or merged away, or one set
+            // by hand that was never right - and answers with an error there is nothing to
+            // cache. Nothing being cached is what makes the next episode ask again, so one bad
+            // id costs a request for every file in the show, every scan. The refusal is
+            // remembered instead, and raised again without asking.
+            if (_refusedIds.TryGetValue(seriesId, out var refusal) && DateTime.UtcNow - refusal.At < _retryAfterRefusal)
+            {
+                throw new InvalidOperationException(refusal.Message);
+            }
+
+            try
+            {
+                await DownloadSeriesData(seriesId, seriesDataPath, appPaths.CachePath, cancellationToken).ConfigureAwait(false);
+
+                _refusedIds.TryRemove(seriesId, out _);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _refusedIds[seriesId] = (DateTime.UtcNow, ex.Message);
+
+                Logger?.LogWarning(
+                    "AniDB refused anime {AnimeId}: {Error}. Nothing more will be asked of that id for {RetryAfter}, so the rest of the show does not spend a request each on the same refusal",
+                    seriesId,
+                    ex.Message,
+                    _retryAfterRefusal);
+
+                throw;
+            }
+        }
+        finally
+        {
+            gate.Release();
         }
 
         return seriesDataPath;
+    }
+
+    /// <summary>
+    /// Whether the cached document of an anime has to be downloaded before it can be read.
+    /// </summary>
+    /// <param name="seriesDataPath">The path of the cached document.</param>
+    /// <returns><c>true</c> when there is no usable copy on disk.</returns>
+    private static bool NeedsDownload(string seriesDataPath)
+    {
+        var fileInfo = new FileInfo(seriesDataPath);
+
+        return !fileInfo.Exists
+            || fileInfo.Length == 0
+            || DateTime.UtcNow - fileInfo.LastWriteTimeUtc > TimeSpan.FromDays(Plugin.Instance.Configuration.MaxCacheAge);
     }
 
     /// <summary>
@@ -289,18 +364,16 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         await _requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            // Task.Delay may fire fractionally early, so re-check rather than assuming a
-            // single delay was enough to clear the interval.
+            // Task.Delay may fire fractionally early, so re-check the interval.
             for (var remaining = GetRemainingInterval(); remaining > TimeSpan.Zero; remaining = GetRemainingInterval())
             {
                 await Task.Delay(remaining < _minimumDelay ? _minimumDelay : remaining, cancellationToken).ConfigureAwait(false);
             }
 
-            // A caller ahead of this one in the queue may have been banned while this one
-            // waited, so re-check instead of draining the whole backlog into a banned server.
+            // A caller ahead in the queue may have been banned while this one waited.
             ThrowIfBanned();
 
-            _nextRequestTimestamp = Stopwatch.GetTimestamp() + _minimumRequestIntervalTicks;
+            _nextRequestTimestamp = Stopwatch.GetTimestamp() + GetRequestIntervalTicks();
         }
         finally
         {
@@ -406,8 +479,8 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     {
         lock (_banLock)
         {
-            // Every successful download lands here, so do nothing unless a ban was actually
-            // in effect. Otherwise the configuration would be rewritten once per series.
+            // Every successful download lands here, so do nothing unless a ban was in
+            // effect. Otherwise the configuration would be rewritten once per series.
             if (!_banActive && _banUntilUtc == DateTime.MinValue && _currentBanBackoff == _initialBanBackoff)
             {
                 return;
@@ -475,14 +548,27 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         }
         catch (Exception ex)
         {
-            // Losing the record only costs the ban its ability to outlive a restart, so this
-            // must not be allowed to fail the metadata request that discovered it.
+            // Losing the record only costs the ban its ability to outlive a restart, which
+            // must not fail the request that discovered it.
             Logger?.LogWarning(ex, "Could not persist the AniDB ban state, so it will not survive a restart");
         }
     }
 
     private static TimeSpan GetRemainingInterval()
         => Stopwatch.GetElapsedTime(Stopwatch.GetTimestamp(), _nextRequestTimestamp);
+
+    /// <summary>
+    /// Gets the configured gap between two AniDB requests, in monotonic clock ticks. Read per
+    /// request so that changing the setting takes effect without a restart.
+    /// </summary>
+    /// <returns>The request interval in <see cref="Stopwatch"/> ticks.</returns>
+    private static long GetRequestIntervalTicks()
+    {
+        var interval = Plugin.Instance?.Configuration.RequestIntervalMs
+            ?? PluginConfiguration.MinimumRequestIntervalMs;
+
+        return (long)(Stopwatch.Frequency * (interval / 1000d));
+    }
 
     private async Task FetchSeriesInfo(MetadataResult<Series> result, string seriesDataPath, string preferredMetadataLangauge)
     {
@@ -926,9 +1012,18 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
             throw new InvalidOperationException("AniDB API error " + errorRegexMatch.Value);
         }
 
+        // An empty body is how the API turns a request away once it has stopped answering, so
+        // it counts as a ban. Treating it as a one-off failure would let a scan carry on
+        // asking, which is what turns a short refusal into a ban measured in days.
         if (string.IsNullOrWhiteSpace(text))
         {
-            throw new InvalidOperationException("AniDB returned an empty response for anime " + aid);
+            var retryAfter = RegisterBan();
+
+            throw new AniDbBannedException(
+                string.Format(CultureInfo.InvariantCulture, "AniDB returned an empty response for anime {0}; pausing all AniDB requests for {1}.", aid, retryAfter))
+            {
+                RetryAfter = retryAfter
+            };
         }
 
         RegisterSuccess();

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/TitleExtensions.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/TitleExtensions.cs
@@ -22,7 +22,7 @@ public static class TitleExtensions
 
         if (preference == TitlePreferenceType.Localized)
         {
-            // prefer an official title, else look for a synonym
+            // Prefer an official title, else a synonym.
             var localized = titlesList.FirstOrDefault(t => t.Language == metadataLanguage && t.Type == "main") ??
                             titlesList.FirstOrDefault(t => t.Language == metadataLanguage && t.Type == "official") ??
                             titlesList.FirstOrDefault(t => t.Language == metadataLanguage && t.Type == "synonym");
@@ -35,7 +35,7 @@ public static class TitleExtensions
 
         if (preference == TitlePreferenceType.Japanese)
         {
-            // prefer an official title, else look for a synonym
+            // Prefer an official title, else a synonym.
             var japanese = titlesList.FirstOrDefault(t => t.Language == "ja" && t.Type == "main") ??
                            titlesList.FirstOrDefault(t => t.Language == "ja" && t.Type == "official") ??
                            titlesList.FirstOrDefault(t => t.Language == "ja" && t.Type == "synonym");
@@ -46,7 +46,7 @@ public static class TitleExtensions
             }
         }
 
-        // return the main title (romaji)
+        // The main title, which is romaji.
         return titlesList.FirstOrDefault(t => t.Language == "x-jat" && t.Type == "main") ??
                titlesList.FirstOrDefault(t => t.Type == "main") ??
                titlesList.FirstOrDefault();

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/TitleExtensions.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/TitleExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Plugin.AniDB.Configuration;
@@ -22,10 +23,14 @@ public static class TitleExtensions
 
         if (preference == TitlePreferenceType.Localized)
         {
-            // Prefer an official title, else a synonym.
-            var localized = titlesList.FirstOrDefault(t => t.Language == metadataLanguage && t.Type == "main") ??
-                            titlesList.FirstOrDefault(t => t.Language == metadataLanguage && t.Type == "official") ??
-                            titlesList.FirstOrDefault(t => t.Language == metadataLanguage && t.Type == "synonym");
+            // English comes last among the candidates, after the language actually asked for.
+            // AniDB holds an official English title for nearly every anime, and it, like the
+            // rest of the candidates, is written in the Latin alphabet, which is what a
+            // displayed title wants to be. Romaji is a transliteration of the Japanese title
+            // rather than a title anyone gave the show, so it is left to the original title
+            // and only used here where there is nothing else.
+            var candidates = LanguageCandidates(metadataLanguage).Append("en").Distinct(StringComparer.Ordinal);
+            var localized = InLanguage(titlesList, candidates);
 
             if (localized != null)
             {
@@ -35,10 +40,7 @@ public static class TitleExtensions
 
         if (preference == TitlePreferenceType.Japanese)
         {
-            // Prefer an official title, else a synonym.
-            var japanese = titlesList.FirstOrDefault(t => t.Language == "ja" && t.Type == "main") ??
-                           titlesList.FirstOrDefault(t => t.Language == "ja" && t.Type == "official") ??
-                           titlesList.FirstOrDefault(t => t.Language == "ja" && t.Type == "synonym");
+            var japanese = InLanguage(titlesList, ["ja"]);
 
             if (japanese != null)
             {
@@ -47,8 +49,103 @@ public static class TitleExtensions
         }
 
         // The main title, which is romaji.
-        return titlesList.FirstOrDefault(t => t.Language == "x-jat" && t.Type == "main") ??
+        return titlesList.FirstOrDefault(t => IsLanguage(t, "x-jat") && t.Type == "main") ??
                titlesList.FirstOrDefault(t => t.Type == "main") ??
                titlesList.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// The first title in one of the given languages, taking the candidates in the order given
+    /// and, within a language, an official title over a synonym.
+    /// </summary>
+    /// <param name="titles">The available titles.</param>
+    /// <param name="candidates">The language tags to look for, most preferred first.</param>
+    /// <returns>The matching title, or <c>null</c> where none of the languages is present.</returns>
+    private static Title? InLanguage(IList<Title> titles, IEnumerable<string> candidates)
+    {
+        foreach (var candidate in candidates)
+        {
+            var match = titles.FirstOrDefault(t => IsLanguage(t, candidate) && t.Type == "main") ??
+                        titles.FirstOrDefault(t => IsLanguage(t, candidate) && t.Type == "official") ??
+                        titles.FirstOrDefault(t => IsLanguage(t, candidate) && t.Type == "synonym");
+
+            if (match != null)
+            {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether a title is written in the language of the given tag. A tag naming only a
+    /// language matches any of AniDB's regional or script variants of it, so that a candidate
+    /// of <c>pt</c> is answered by AniDB's <c>pt-BR</c> and one of <c>zh</c> by <c>zh-Hans</c>.
+    /// </summary>
+    /// <param name="title">The title to test.</param>
+    /// <param name="candidate">The language tag to test it against, in lower case.</param>
+    /// <returns><c>true</c> where the title is in that language.</returns>
+    private static bool IsLanguage(Title title, string candidate)
+    {
+        var language = title.Language;
+
+        if (string.IsNullOrEmpty(language))
+        {
+            return false;
+        }
+
+        return string.Equals(language, candidate, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(PrimaryTag(language), candidate, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The language tags to try for the metadata language Jellyfin asked for, most preferred
+    /// first. Jellyfin names a language by a code that may carry a country, such as
+    /// <c>pt-br</c> or <c>zh-cn</c>, whereas AniDB names one either plainly, as <c>pt</c>, or
+    /// by script, as <c>zh-Hans</c>. Asking for the exact code alone therefore misses a title
+    /// AniDB does hold, and everything falls through to romaji.
+    /// </summary>
+    /// <param name="metadataLanguage">The metadata language Jellyfin asked for.</param>
+    /// <returns>The language tags to look for, in lower case.</returns>
+    private static IEnumerable<string> LanguageCandidates(string metadataLanguage)
+    {
+        if (string.IsNullOrWhiteSpace(metadataLanguage))
+        {
+            return [];
+        }
+
+        var requested = metadataLanguage.Trim().ToLowerInvariant();
+        var primary = PrimaryTag(requested);
+        var candidates = new List<string> { requested };
+
+        // AniDB writes Chinese by script rather than by country. Which script a country
+        // reads is not something the country code itself says, so map the ones AniDB's
+        // titles are actually written in, and offer the other script last: a title in the
+        // wrong Chinese script is still closer than a romaji one.
+        if (primary == "zh")
+        {
+            var simplified = requested is "zh" or "zh-cn" or "zh-sg" or "zh-my" or "zh-hans";
+
+            candidates.Add(simplified ? "zh-hans" : "zh-hant");
+            candidates.Add(simplified ? "zh-hant" : "zh-hans");
+        }
+
+        candidates.Add(primary);
+
+        return candidates.Distinct(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The part of a language tag naming the language itself, without the country or script
+    /// that may follow it.
+    /// </summary>
+    /// <param name="tag">The language tag.</param>
+    /// <returns>The tag's first subtag.</returns>
+    private static string PrimaryTag(string tag)
+    {
+        var separator = tag.IndexOf('-', StringComparison.Ordinal);
+
+        return separator < 0 ? tag : tag[..separator];
     }
 }

--- a/Jellyfin.Plugin.AniDB/Providers/GenreHelper.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/GenreHelper.cs
@@ -9,208 +9,137 @@ namespace Jellyfin.Plugin.AniDB.Providers;
 
 public static class GenreHelper
 {
-    private static readonly Dictionary<string, string> GenreMappings = new()
+    /// <summary>
+    /// Maps the AniDB tags that describe what a show is onto the genre names to display, and
+    /// by doing so decides which tags are genres at all. Of AniDB's ~4700 tags, nearly all name
+    /// a plot element, a setting or a production detail; anything absent from this table is
+    /// left as a tag only.
+    /// </summary>
+    private static readonly Dictionary<string, string> GenreMappings = new(StringComparer.OrdinalIgnoreCase)
     {
-        { "Action", "Action" },
-        { "Advanture", "Adventure" },
-        { "Contemporary Fantasy", "Fantasy" },
-        { "Comedy", "Comedy" },
-        { "Dark Fantasy", "Fantasy" },
-        { "Dementia", "Psychological Thriller" },
-        { "Demons", "Fantasy" },
-        { "Drama", "Drama" },
-        { "Ecchi", "Ecchi" },
-        { "Fantasy", "Fantasy" },
-        { "Harem", "Harem" },
-        { "Hentai", "Adult" },
-        { "Historical", "Period & Historical" },
-        { "Horror", "Horror" },
-        { "Josei", "Josei" },
-        { "Kids", "Kids" },
-        { "Magic", "Fantasy" },
-        { "Martial Arts", "Martial Arts" },
-        { "Mahou Shoujo", "Mahou Shoujo" },
-        { "Mecha", "Mecha" },
-        { "Music", "Music" },
-        { "Mystery", "Mystery" },
-        { "Parody", "Comedy" },
-        { "Psychological", "Psychological Thriller" },
-        { "Romance", "Romance" },
-        { "Sci-Fi", "Sci-Fi" },
-        { "Seinen", "Seinen" },
-        { "Shoujo", "Shoujo" },
-        { "Shounen", "Shounen" },
-        { "Slice of Life", "Slice of Life" },
-        { "Space", "Sci-Fi" },
-        { "Sports", "Sport" },
-        { "Supernatural", "Supernatural" },
-        { "Thriller", "Thriller" },
-        { "Tragedy", "Tragedy" },
-        { "Witch", "Supernatural" },
-        { "Vampire", "Supernatural" },
-        { "Yaoi", "Adult" },
-        { "Yuri", "Adult" },
-        { "Zombie", "Supernatural" },
+        // Core genres.
+        { "action", "Action" },
+        { "adventure", "Adventure" },
+        { "comedy", "Comedy" },
+        { "parody", "Comedy" },
+        { "horror", "Horror" },
+        { "mystery", "Mystery" },
+        { "detective", "Mystery" },
+        { "romance", "Romance" },
+        { "thriller", "Thriller" },
+        { "psychological", "Psychological Thriller" },
+        { "tragedy", "Tragedy" },
+        { "crime", "Crime" },
+        { "police", "Crime" },
+        { "historical", "Historical" },
+        { "samurai", "Historical" },
+        { "military", "Military" },
+        { "war", "Military" },
+        { "music", "Music" },
+        { "idol", "Music" },
+        { "sports", "Sports" },
+        { "cooking", "Cooking" },
+
+        // Fantasy and the creature tags that stand in for it.
+        { "fantasy", "Fantasy" },
+        { "contemporary fantasy", "Fantasy" },
+        { "dark fantasy", "Fantasy" },
+        { "high fantasy", "Fantasy" },
+        { "magic", "Fantasy" },
+        { "dragon", "Fantasy" },
+        { "demon", "Supernatural" },
+        { "angel", "Supernatural" },
+        { "ghost", "Supernatural" },
+        { "vampire", "Supernatural" },
+        { "zombie", "Supernatural" },
+        { "magical girl", "Mahou Shoujo" },
+        { "isekai", "Isekai" },
+
+        // Science fiction and its sub-genres.
+        { "science fiction", "Sci-Fi" },
+        { "space opera", "Sci-Fi" },
+        { "cyberpunk", "Sci-Fi" },
+        { "post-apocalyptic", "Sci-Fi" },
+        { "space", "Sci-Fi" },
+        { "time travel", "Sci-Fi" },
+        { "android", "Sci-Fi" },
+        { "mecha", "Mecha" },
+        { "robot", "Mecha" },
+
+        // Setting and combat tags that read as genres.
+        { "daily life", "Slice of Life" },
+        { "school life", "School Life" },
+        { "high school", "School Life" },
+        { "martial arts", "Martial Arts" },
+        { "super power", "Super Power" },
+        { "swordplay", "Action" },
+        { "gunfights", "Action" },
+
+        // Target audience.
+        { "shounen", "Shounen" },
+        { "shoujo", "Shoujo" },
+        { "seinen", "Seinen" },
+        { "josei", "Josei" },
+        { "kodomo", "Kodomo" },
+
+        // Romance sub-genres and content rating.
+        { "harem", "Harem" },
+        { "reverse harem", "Harem" },
+        { "ecchi", "Ecchi" },
+        { "yuri", "Yuri" },
+        { "shoujo ai", "Yuri" },
+        { "yaoi", "Yaoi" },
+        { "shounen ai", "Yaoi" },
+        { "18 restricted", "Adult" },
+        { "pornography", "Adult" },
     };
 
-    private static readonly string[] GenresAsTags =
-    [
-        "Hentai",
-        "Space",
-        "Weltraum",
-        "Yaoi",
-        "Yuri",
-        "Demons",
-        "Witch",
-        // AniSearchTags
-        "Krieg",
-        "Militär",
-        "Satire",
-        "Übermäßige Gewaltdarstellung",
-        "Monster",
-        "Zeitgenössische Fantasy",
-        "Dialogwitz",
-        "Romantische Komödie",
-        "Slapstick",
-        "Alternative Welt",
-        "4-panel",
-        "CG-Anime",
-        "Episodisch",
-        "Moe",
-        "Parodie",
-        "Splatter",
-        "Tragödie",
-        "Verworrene Handlung",
-        // Themen
-        "Erwachsenwerden",
-        "Gender Bender",
-        "Ältere Frau, jüngerer Mann",
-        "Älterer Mann, jüngere Frau",
-        // Schule (School)
-        "Grundschule",
-        "Kindergarten",
-        "Klubs",
-        "Mittelschule",
-        "Oberschule",
-        "Schule",
-        "Universität",
-        // Zeit (Time)
-        "Altes Asien",
-        "Frühe Neuzeit",
-        "Gegenwart",
-        "industrialisierung",
-        "Meiji-Ära",
-        "Mittelalter",
-        "Weltkriege",
-        // Fantasy
-        "Dunkle Fantasy",
-        "Epische Fantasy",
-        "Zeitgenössische Fantasy",
-        // Ort
-        "Alternative Welt",
-        "In einem Raumschiff",
-        "Weltraum",
-        // Setting
-        "Cyberpunk",
-        "Endzeit",
-        "Space Opera",
-        // Hauptfigur
-        "Charakterschache Heldin",
-        "Charakterschacher Held",
-        "Charakterstarke Heldin",
-        "Charakterstarker Held",
-        "Gedächtnisverlust",
-        "Stoische Heldin",
-        "Stoischer Held",
-        "Widerwillige Heldin",
-        "Widerwilliger Held",
-        // Figuren
-        "Diva",
-        "Genie",
-        "Schul-Delinquent",
-        "Tomboy",
-        "Tsundere",
-        "Yandere",
-        // Kampf (fight)
-        "Bionische Kräfte",
-        "Martial Arts",
-        "PSI-Kräfte",
-        "Real Robots",
-        "Super Robots",
-        "Schusswaffen",
-        "Schwerter & co",
-        // Sports (Sport)
-        "Baseball",
-        "Boxen",
-        "Denk- und Glücksspiele",
-        "Football",
-        "Fußball",
-        "Kampfsport",
-        "Rennsport",
-        "Tennis",
-        // Kunst (Art)
-        "Anime & Film",
-        "Malerei",
-        "Manga & Doujinshi",
-        "Musik",
-        "Theater",
-        // Tätigkeit
-        "Band",
-        "Detektiv",
-        "Dieb",
-        "Essenszubereitung",
-        "Idol",
-        "Kopfgeldjäger",
-        "Ninja",
-        "Polizist",
-        "Ritter",
-        "Samurai",
-        "Solosänger",
-        // Wesen
-        "Außerirdische",
-        "Cyborgs",
-        "Dämonen",
-        "Elfen",
-        "Geister",
-        "Hexen",
-        "Himmlische Wesen",
-        "Kamis",
-        "Kemonomimi",
-        "Monster",
-        "Roboter & Androiden",
-        "Tiermenschen",
-        "Vampire",
-        "Youkai",
-        "Zombie",
-    ];
-
-    private static readonly Dictionary<string, string> IgnoreIfPresent = new()
+    /// <summary>
+    /// Genres that are implied by a more specific one, and so are dropped when it is present.
+    /// Keyed by the specific genre, valued by the one it makes redundant.
+    /// </summary>
+    private static readonly Dictionary<string, string> IgnoreIfPresent = new(StringComparer.OrdinalIgnoreCase)
     {
         { "Psychological Thriller", "Thriller" }
     };
 
-    private static readonly string[] second = new[] { "Animation", "Anime" };
+    private static readonly string[] second = ["Animation", "Anime"];
 
     public static void CleanupGenres(Series series)
     {
         PluginConfiguration config = Plugin.Instance.Configuration;
 
+        // Before mapping, so the names the table produces keep the casing it spells them
+        // with: title casing "Slice of Life" would give "Slice Of Life".
         if (config.TitleCaseGenres)
         {
-            series.Genres = [.. series.Genres.Select(g => CultureInfo.InvariantCulture.TextInfo.ToTitleCase(g))];
+            series.Genres = [.. series.Genres.Select(TitleCase)];
+            series.Tags = [.. series.Tags.Select(TitleCase)];
+        }
+
+        if (!config.ImportTags)
+        {
+            series.Tags = [];
+        }
+
+        if (!config.ImportGenres)
+        {
+            series.Genres = [];
+
+            return;
         }
 
         if (config.TidyGenreList)
         {
-            series.Genres = [.. RemoveRedundantGenres(series.Genres).Distinct()];
-
             TidyGenres(series);
+
+            series.Genres = [.. RemoveRedundantGenres(series.Genres).Distinct(StringComparer.OrdinalIgnoreCase)];
         }
 
         if (config.AnimeDefaultGenre != AnimeDefaultGenreType.None)
         {
             series.Genres = [.. series.Genres
-                .Except(second)
+                .Except(second, StringComparer.OrdinalIgnoreCase)
                 .Prepend(config.AnimeDefaultGenre.ToString())];
         }
 
@@ -222,10 +151,16 @@ public static class GenreHelper
         series.Genres = [.. series.Genres.OrderBy(i => i)];
     }
 
+    /// <summary>
+    /// Keeps only the AniDB tags that name a genre, under the genre name to display them by.
+    /// The rest are already held as tags.
+    /// </summary>
+    /// <param name="series">The series whose genres to sort out.</param>
     public static void TidyGenres(Series series)
     {
-        var genres = new HashSet<string>();
-        var tags = new HashSet<string>(series.Tags);
+        // Insertion order is kept so the genres AniDB weighted highest survive the MaxGenres
+        // trim, which happens before the list is sorted for display.
+        var genres = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (string genre in series.Genres)
         {
@@ -233,26 +168,19 @@ public static class GenreHelper
             {
                 genres.Add(mapped);
             }
-            else
-            {
-                genres.Add(genre);
-            }
-
-            if (GenresAsTags.Contains(genre))
-            {
-                genres.Add(genre);
-            }
         }
 
         series.Genres = [.. genres];
-        series.Tags = [.. tags];
     }
+
+    private static string TitleCase(string value)
+        => CultureInfo.InvariantCulture.TextInfo.ToTitleCase(value);
 
     public static IEnumerable<string> RemoveRedundantGenres(IEnumerable<string> genres)
     {
         var list = genres as IList<string> ?? [.. genres];
 
         var toRemove = list.Where(IgnoreIfPresent.ContainsKey).Select(genre => IgnoreIfPresent[genre]).ToList();
-        return list.Where(genre => !toRemove.Contains(genre));
+        return list.Where(genre => !toRemove.Contains(genre, StringComparer.OrdinalIgnoreCase));
     }
 }

--- a/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +15,18 @@ namespace Jellyfin.Plugin.AniDB.Providers;
 /// </summary>
 internal static partial class Equals_check
 {
+    /// <summary>
+    /// How far apart two short names may be and still be the same show. Below this, the
+    /// proportional bar would demand a near-exact spelling of a name too short to afford one.
+    /// </summary>
+    private const int MinimumTitleDistance = 3;
+
+    /// <summary>
+    /// How many of the closest matches to offer when none of them clears the bar, so that a
+    /// name AniDB spells quite differently still turns something up to choose from.
+    /// </summary>
+    private const int FallbackSearchResults = 3;
+
     /// <summary>
     /// Cut p(%) away from the string.
     /// </summary>
@@ -87,58 +101,98 @@ internal static partial class Equals_check
     }
 
     /// <summary>
-    /// simple regex.
-    /// </summary>
-    /// <param name="regex">The regex to match with.</param>
-    /// <param name="input">The input to match against.</param>
-    /// <param name="group">The capture group to return.</param>
-    /// <param name="matchInt">The index of the match to return.</param>
-    /// <returns>The captured value, or an empty string when there is no match.</returns>
-    public static string OneLineRegex(Regex regex, string input, int group = 1, int matchInt = 0)
-    {
-        int x = 0;
-        foreach (Match match in regex.Matches(input))
-        {
-            if (x == matchInt)
-            {
-                return match.Groups[group].Value;
-            }
-
-            x++;
-        }
-
-        return string.Empty;
-    }
-
-    /// <summary>
-    /// Searches for possible AniDB IDs for name.
+    /// Searches for possible AniDB IDs for name, closest spelling first.
     /// </summary>
     /// <param name="name">The name to search for.</param>
+    /// <param name="limit">How many ids to return at most.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="x_">The current attempt; the titles file is downloaded once when it cannot be read.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation, containing the matching AniDB IDs.</returns>
-    public static async Task<List<string>> XmlSearch(string name, CancellationToken cancellationToken, int x_ = 0)
+    public static async Task<List<string>> XmlSearch(string name, int limit, CancellationToken cancellationToken, int x_ = 0)
     {
         string? xml = await ReadTitlesXml(x_, cancellationToken).ConfigureAwait(false);
 
-        return xml is null ? [] : SearchTitlesXml(xml, name);
+        if (xml is null)
+        {
+            return [];
+        }
+
+        var results = SearchTitlesXml(xml, name);
+
+        if (results.Count == 0)
+        {
+            return results;
+        }
+
+        // The fuzzy search cuts a name to its first few letters and then makes even those
+        // optional, so a short name matches every show that merely starts alike: "Oshi no Ko"
+        // returns 78 of them, only three of which are the show. Each id handed back costs the
+        // caller an AniDB request, so they are ordered by how close their closest title really
+        // is and cut down to the ones that could be spellings of the same name.
+        var entriesById = IndexEntries(xml);
+        var strippedName = StripYearRegex().Replace(name, string.Empty).Trim();
+
+        var ranked = results
+            .Distinct(StringComparer.Ordinal)
+            .Select(id => (Id: id, Distance: entriesById.TryGetValue(id, out var entry) ? BestDistance(entry, strippedName) : int.MaxValue))
+            .OrderBy(candidate => candidate.Distance)
+            .ToList();
+
+        // Half a name may differ before it stops being a spelling of the same title. A short
+        // name gets a floor under that, because three letters out of six is still the same
+        // show once romanisation has had its way with it.
+        var bar = Math.Max(MinimumTitleDistance, strippedName.Length / 2);
+        var withinBar = ranked.Where(candidate => candidate.Distance <= bar).ToList();
+
+        // Nothing within the bar means the library spells this name quite unlike AniDB does.
+        // The closest few are still the best answer there is, and an empty identify dialog is
+        // no answer at all.
+        var chosen = withinBar.Count > 0 ? withinBar : ranked.Take(FallbackSearchResults);
+
+        return [.. chosen.Take(limit).Select(candidate => candidate.Id)];
     }
 
     /// <summary>
     /// Finds an AniDB ID for name.
     /// </summary>
     /// <param name="name">The name to search for.</param>
+    /// <param name="year">The year the series is known to be from, used to tell apart two shows of the same name.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="x_">The current attempt; the titles file is downloaded once when it cannot be read.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation, containing the best matching AniDB ID.</returns>
-    public static async Task<string> XmlFindId(string name, CancellationToken cancellationToken, int x_ = 0)
+    public static async Task<string> XmlFindId(string name, int? year, CancellationToken cancellationToken, int x_ = 0)
     {
-        // Read the titles file once and reuse it for both the search and the comparison
-        // below; it is several megabytes, and this used to read it twice per lookup.
+        // Read once and reuse for both the search and the comparison below; the file is
+        // several megabytes.
         string? xml = await ReadTitlesXml(x_, cancellationToken).ConfigureAwait(false);
         if (xml is null)
         {
             return string.Empty;
+        }
+
+        var strippedName = StripYearRegex().Replace(name, string.Empty).Trim();
+
+        var entriesById = IndexEntries(xml);
+
+        // A title AniDB spells as the library does settles the question, and settles it without
+        // the fuzzy search, which reduces a name to its first few letters and so returns every
+        // show whose name begins alike.
+        //
+        // The name is tried with the year first. Two shows made years apart under one name are
+        // told apart by nothing else, and AniDB gives the later one a title carrying its year,
+        // which is what this matches. The year is put back because the scanner has already
+        // taken it out of the name and into its own field. Each spelling is tried as written
+        // before being reduced to its letters and digits, so that a title differing only in
+        // punctuation - a sequel marked with an apostrophe, say - cannot take the original's
+        // place.
+        foreach (var (candidate, loose) in GetNameCandidates(name, strippedName, year))
+        {
+            var matches = FindByTitle(entriesById, candidate, loose);
+
+            if (matches.Count == 1)
+            {
+                return matches[0];
+            }
         }
 
         var results = SearchTitlesXml(xml, name);
@@ -151,15 +205,6 @@ internal static partial class Equals_check
         int lowestDistance = Plugin.Instance.Configuration.TitleSimilarityThreshold;
         string currentId = string.Empty;
 
-        // Index every entry once with a constant pattern, rather than building and compiling a
-        // fresh regex per candidate id inside the loop. Keep the first entry for an id so the
-        // behaviour matches the previous "first match wins" lookup.
-        var entriesById = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (Match entry in AnimeEntryRegex().Matches(xml))
-        {
-            entriesById.TryAdd(entry.Groups[1].Value, entry.Groups[2].Value);
-        }
-
         foreach (string id in results)
         {
             if (!entriesById.TryGetValue(id, out string? nameXmlFromId))
@@ -167,27 +212,168 @@ internal static partial class Equals_check
                 continue;
             }
 
-            string[] lines = nameXmlFromId.Split(
-                ["\r\n", "\r", "\n"],
-                StringSplitOptions.None);
+            int stringDistance = BestDistance(nameXmlFromId, strippedName);
 
-            foreach (string line in lines)
+            if (lowestDistance > stringDistance)
             {
-                string nameFromId = OneLineRegex(TitleRegex(), line);
-
-                if (!string.IsNullOrEmpty(nameFromId))
-                {
-                    int stringDistance = LevenshteinDistance(name, nameFromId);
-                    if (lowestDistance > stringDistance)
-                    {
-                        lowestDistance = stringDistance;
-                        currentId = id;
-                    }
-                }
+                lowestDistance = stringDistance;
+                currentId = id;
             }
         }
 
         return currentId;
+    }
+
+    /// <summary>
+    /// Every entry of the titles file, by AniDB id. Indexed once with a constant pattern
+    /// rather than by compiling a fresh regex per candidate id; the first entry for an id
+    /// wins.
+    /// </summary>
+    /// <param name="xml">The titles file.</param>
+    /// <returns>The entries, by AniDB id.</returns>
+    private static Dictionary<string, string> IndexEntries(string xml)
+    {
+        var entriesById = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (Match entry in AnimeEntryRegex().Matches(xml))
+        {
+            entriesById.TryAdd(entry.Groups[1].Value, entry.Groups[2].Value);
+        }
+
+        return entriesById;
+    }
+
+    /// <summary>
+    /// How far the closest of an entry's titles is from the given name. Compared without the
+    /// year, which AniDB writes into a title only where it has to. Leaving it in counts every
+    /// one of its characters as a difference, which is enough to lose the right entry to a
+    /// longer name that happens to carry digits.
+    /// </summary>
+    /// <param name="entryXml">The entry, as the titles file holds it.</param>
+    /// <param name="strippedName">The name to compare against, with any trailing year removed.</param>
+    /// <returns>The smallest edit distance across the entry's titles.</returns>
+    private static int BestDistance(string entryXml, string strippedName)
+    {
+        var lowest = int.MaxValue;
+
+        foreach (Match title in TitleRegex().Matches(entryXml))
+        {
+            var titleText = title.Groups[1].Value;
+
+            if (!string.IsNullOrEmpty(titleText))
+            {
+                lowest = Math.Min(lowest, LevenshteinDistance(strippedName, titleText));
+            }
+        }
+
+        return lowest;
+    }
+
+    /// <summary>
+    /// The spellings of a name to look for, in the order they settle a match. A spelling
+    /// carrying the year comes before one without, and an exact spelling before a reduced one.
+    /// </summary>
+    /// <param name="name">The name as the library holds it.</param>
+    /// <param name="strippedName">The same name with any trailing year removed.</param>
+    /// <param name="year">The year the series is known to be from.</param>
+    /// <returns>Each spelling, and whether to compare it reduced to letters and digits.</returns>
+    private static IEnumerable<(string Candidate, bool Loose)> GetNameCandidates(string name, string strippedName, int? year)
+    {
+        var withYear = year.HasValue
+            ? FormattableString.Invariant($"{strippedName} ({year.Value})")
+            : null;
+
+        foreach (var loose in new[] { false, true })
+        {
+            if (withYear != null)
+            {
+                yield return (withYear, loose);
+            }
+
+            if (!string.Equals(name, withYear, StringComparison.Ordinal))
+            {
+                yield return (name, loose);
+            }
+
+            if (!string.Equals(strippedName, name, StringComparison.Ordinal)
+                && !string.Equals(strippedName, withYear, StringComparison.Ordinal))
+            {
+                yield return (strippedName, loose);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The ids of every entry AniDB gives the given title to, matched whole rather than fuzzily.
+    /// </summary>
+    /// <param name="entriesById">Every entry of the titles file, by AniDB id.</param>
+    /// <param name="name">The name to look for.</param>
+    /// <param name="loose">Whether to compare the names reduced to their letters and digits, rather than as written.</param>
+    /// <returns>The matching AniDB ids.</returns>
+    private static List<string> FindByTitle(IReadOnlyDictionary<string, string> entriesById, string name, bool loose)
+    {
+        var matches = new List<string>();
+        var wanted = NormalizeTitle(name, loose);
+
+        if (wanted.Length == 0)
+        {
+            return matches;
+        }
+
+        foreach (var entry in entriesById)
+        {
+            foreach (Match title in TitleRegex().Matches(entry.Value))
+            {
+                if (string.Equals(NormalizeTitle(title.Groups[1].Value, loose), wanted, StringComparison.Ordinal))
+                {
+                    matches.Add(entry.Key);
+
+                    break;
+                }
+            }
+        }
+
+        return matches;
+    }
+
+    /// <summary>
+    /// Reduces a title for comparison. Case and runs of whitespace never distinguish two
+    /// spellings of a name; punctuation is dropped only when asked, because an apostrophe or a
+    /// full stop is sometimes the whole difference between a show and its sequel. A year is
+    /// always kept: it is what tells a remake from the show it is named after.
+    /// </summary>
+    /// <param name="value">The title to reduce.</param>
+    /// <param name="loose">Whether to drop everything that is not a letter or a digit.</param>
+    /// <returns>The reduced title.</returns>
+    private static string NormalizeTitle(string value, bool loose)
+    {
+        var builder = new StringBuilder(value.Length);
+        var pendingSpace = false;
+
+        foreach (var character in value)
+        {
+            if (char.IsWhiteSpace(character))
+            {
+                pendingSpace = builder.Length > 0;
+
+                continue;
+            }
+
+            if (loose && !char.IsLetterOrDigit(character))
+            {
+                continue;
+            }
+
+            if (pendingSpace && !loose)
+            {
+                builder.Append(' ');
+            }
+
+            pendingSpace = false;
+            builder.Append(char.ToUpperInvariant(character));
+        }
+
+        return builder.ToString();
     }
 
     /// <summary>
@@ -316,10 +502,10 @@ internal static partial class Equals_check
     [GeneratedRegex(@"s\b")]
     private static partial Regex SAtEndBoundaryRegex();
 
-    [GeneratedRegex(@"<title.*>([^<]+)</title>")]
+    [GeneratedRegex(@"<title[^>]*>([^<]+)</title>")]
     private static partial Regex TitleRegex();
 
-    [GeneratedRegex(@" \([0-9]{4}\)$")]
+    [GeneratedRegex(@"\s*\([0-9]{4}\)\s*$")]
     private static partial Regex StripYearRegex();
 
     [GeneratedRegex(@"<anime aid=""([0-9]+)""((?s).*?)</anime>")]

--- a/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
@@ -46,7 +46,7 @@ internal static partial class Equals_check
     {
         a = Regex.Escape(a);
 
-        // make characters that were escaped fuzzy
+        // Make the escaped characters fuzzy.
         a = a.Replace(@"\\", ".?", StringComparison.Ordinal);
         a = a.Replace(@"\*", ".?", StringComparison.Ordinal);
         a = a.Replace(@"\+", ".?", StringComparison.Ordinal);
@@ -61,14 +61,14 @@ internal static partial class Equals_check
         a = a.Replace(@"\.", ".?", StringComparison.Ordinal);
         a = a.Replace(@"\#", ".?", StringComparison.Ordinal);
 
-        // whitespace
+        // Whitespace.
         a = a.Replace(@"\ ", ".?.?.?", StringComparison.Ordinal);
         a = WhitespaceRegex().Replace(a, ".?.?.?");
 
-        // other characters
+        // Other characters.
         a = SpecialCharacterRegex().Replace(a, ".?");
 
-        // "words"
+        // Words.
         a = SAtEndBoundaryRegex().Replace(a, ".?s");
         a = a.Replace("Gekijyouban", "Gekijouban", StringComparison.OrdinalIgnoreCase);
         a = a.Replace("Mahoutsukai", "Mahou ?tsukai", StringComparison.OrdinalIgnoreCase);
@@ -275,15 +275,15 @@ internal static partial class Equals_check
         var results = new List<string>();
         string strippedName = StripYearRegex().Replace(name, string.Empty);
 
-        // The pattern embeds the search term as a fuzzy expression, so it cannot be a
-        // [GeneratedRegex]. Compiled is worth its build cost here: the atomic group
-        // backtracks heavily across a multi-megabyte document.
+        // The pattern embeds the search term, so it cannot be a [GeneratedRegex]. Compiled
+        // earns its build cost: the atomic group backtracks heavily across a multi-megabyte
+        // document.
         var searchRegex = new Regex(
             @"<anime aid=""([0-9]+)"">(?>[^<>]+|<(?!\/anime>)[^<>]*>)*?.*" + FuzzyRegexEscape(ShortenString(strippedName, 6, 20)),
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        // Enumerate the matches once. Indexing into them one at a time re-scanned the whole
-        // document for every result, which made a common name quadratic in its match count.
+        // Enumerate once. Indexing in one at a time rescans the whole document per result,
+        // which is quadratic in the match count for a common name.
         foreach (Match match in searchRegex.Matches(xml))
         {
             string id = match.Groups[1].Value;

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ keeps inside another entry. Writing
 states such a thing outright. What it names is used as it stands, ahead of both sources; what it
 does not name is left to them. There is no setting to turn it on: the file being there is the
 setting, it is read again within five minutes of being changed, and the plugin page's **Status**
-section says where it goes, when it was last written and how many entries were read from it.
+section says where it goes, when it was last written and what has been read from it.
 
 The format is the AniBridge schema, so anything already written for those mappings can be pasted
 in. One key per AniDB entry, naming which of the entry's numberings it maps from, and under it
@@ -63,6 +63,26 @@ one key per season, naming ranges of the entry against ranges of the season:
 - The third corrects one season of a show the downloaded sources already place. The entry named
   need not be the one the show is identified as; the TVDB id is what ties the two together.
 
+A season's side can also list several ranges, and can end with a ratio weighting its episodes
+against the entry's, both of which the AniBridge schema writes and this reads:
+
+- `"1-12": "1-6,8-13"` names two ranges: the entry's twelve episodes fill the season's 1-6 and
+  8-13, leaving its episode 7 to be matched some other way. The schema lists several ranges on
+  the season's side only.
+- `"13-": "14-|2"` weights them two to one: each episode of the entry is two of the season's, so
+  the entry's 13 is the season's 14 and 15, its 14 is the season's 16 and 17, and both halves of
+  each are described by the one AniDB episode holding them. That is a library numbering a
+  two-part episode as two where AniDB lists it as one.
+- `"1-4": "1-2|-2"` weights them the other way about, a negative ratio being that many of the
+  entry's episodes to one of the season's: the entry's 1 and 2 are the season's episode 1, its 3
+  and 4 the season's 2. The season's episode is described by the first of the pair, AniDB
+  recording two and a library holding them as one episode having one place to put them.
+
+The ratio belongs to the season's side, and its sign says which way round the weighting goes, so
+there is nothing to write on the entry's side: `"1-2": "1|-2"` is what `"1": "1-2|2"` would say
+backwards. A run with no end written is weighted out as far as any season could run and no
+further.
+
 Two things to know when writing one:
 
 - A placement is checked against AniDB, and dropped with a warning in the log if it reads past
@@ -71,6 +91,36 @@ Two things to know when writing one:
 - A season the file places is not measured against how many episodes your library holds under
   it, which is what lets a deliberately partial placement stand. The episodes it leaves out get
   no metadata rather than being placed some other way.
+
+### Movies
+
+A movie is named by its own id with whichever provider rather than by a season, since your library
+holds it as one item:
+
+```json
+{
+  "anidb:7:R": { "tmdb_movie:128": { "1": "1" }, "imdb_movie:tt0119698": { "1": "1" } },
+  "anidb:665:O": { "tmdb_movie:123456": { "3": "1" } }
+}
+```
+
+`tmdb_movie:`, `imdb_movie:` and `tvdb_movie:` are all read, and TVDB numbers its movies apart
+from its series. The left side is the episode of the entry the movie is; the right side is always
+`1`, a movie having nothing to number.
+
+- The first line is a movie AniDB registered in its own right - anime 7 is Princess Mononoke, and
+  those are its real ids - so the movie is that entry's episode 1 and is described by the entry's
+  own record.
+- The second is a movie AniDB holds inside an entry registered for something else, under whatever
+  id your own copy carries: Berserk's Memorial Edition, a theatrical cut listed among a series'
+  other episodes. There the movie takes its name, date and running time from **that episode**
+  rather than from the entry, so several such movies of one show no longer come out as several
+  copies of the same title. Cast, studios, genres and rating still come from the entry: AniDB
+  records none of those per episode.
+
+Movies are also identified from the downloaded sources now, with no file of your own - AniBridge
+maps 2,853 of them and the anime list 2,084 - so a movie another provider has already given a
+TMDB, IMDb or TVDB id needs an override only where those two are wrong about it or silent.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,58 @@
 
 This plugin adds the metadata provider for [aniDB](https://anidb.net/).
 
+## Mapping overrides
+
+The plugin works out which AniDB entry fills which season from two downloaded sources, the
+[AniBridge mappings](https://github.com/anibridge/anibridge-mappings) and the
+[Anime-Lists](https://github.com/Anime-Lists/anime-lists) anime list. Both describe AniDB as it
+is, so neither can describe a library that holds something AniDB does not list, or a show AniDB
+keeps inside another entry. Writing
+
+```
+<jellyfin config>/plugins/configurations/anidb-mapping-overrides.json
+```
+
+states such a thing outright. What it names is used as it stands, ahead of both sources; what it
+does not name is left to them. There is no setting to turn it on: the file being there is the
+setting, it is read again within five minutes of being changed, and the plugin page's **Status**
+section says where it goes, when it was last written and how many entries were read from it.
+
+The format is the AniBridge schema, so anything already written for those mappings can be pasted
+in. One key per AniDB entry, naming which of the entry's numberings it maps from, and under it
+one key per season, naming ranges of the entry against ranges of the season:
+
+```json
+{
+  "anidb:665:O": { "tvdb_show:70873:s3": { "1-13": "1-13" } },
+  "anidb:4521:S": { "tvdb_show:79093:s0": { "1-6": "1-6", "7-12": "8-13" } },
+  "anidb:7777:R": { "tvdb_show:441190:s4": { "1-12": "1-12" } }
+}
+```
+
+- `anidb:<id>:R` numbers the entry's ordinary episodes, `:S` its specials and `:O` its other
+  episodes. `tvdb_show:<id>:s<n>` is the season as your library numbers it, `s0` being the
+  specials. Ranges are `first-last` or a single number, the entry's on the left and the season's
+  on the right.
+- The first line above is a show AniDB holds as another entry's *other* episodes - Berserk's
+  Golden Age Arc Memorial Edition and Hellsing Ultimate Abridged are held that way. It both
+  identifies the show, there being no entry of its own to match by name, and fills its season.
+- The second is a specials season holding one special AniDB does not list, at position 7:
+  everything after it is one out of step, which without this costs the whole season its
+  numbering. Season specials named by no range - 7 here - are left to be matched by title and
+  air date, as any other unplaced special is.
+- The third corrects one season of a show the downloaded sources already place. The entry named
+  need not be the one the show is identified as; the TVDB id is what ties the two together.
+
+Two things to know when writing one:
+
+- A placement is checked against AniDB, and dropped with a warning in the log if it reads past
+  the end of the entry it names. Only ordinary episodes can be checked that way: AniDB publishes
+  no count of an entry's specials or other episodes, so a range over those is taken at your word.
+- A season the file places is not measured against how many episodes your library holds under
+  it, which is what lets a deliberately partial placement stand. The episodes it leaves out get
+  no metadata rather than being placed some other way.
+
 ## Installation
 
 [See the official documentation for install instructions](https://jellyfin.org/docs/general/server/plugins/index.html#installing).


### PR DESCRIPTION
**Closes/fixes**
- #6 (i think mostly done and outdated based on age)
- #11 (needs testing, but matches always for me and sounds more like core)
- #22 (fixed - added to core)
- #43 (fixed)
- #53 (fixed)
- #58 (fixed)
- #61 (fixed - because mapping is used + you can overwrite it + `[anidb=]` is now supported in core])
- #70 (fixed)
- #77 (fixed and duplicate)
- #80 (fixed - duplicate)
- #82 (fixed)
- #88 (fixed)
- #94 (should be fixed)
- 96 (fixed)
- #98 (done - inside the issue a spoiler filter is wanted (attribute in tag xml)

Maybe close
- #16 (issue is rate limit, just look for aniDB id)


---

**Replaces PRs**
- #97
- #40
- #36

**Outdated for unstable**
- #90
