### PR TITLE
Close out six open issues across metadata, matching and artwork

### DIFF
--- a/Jellyfin.Plugin.AniDB.Tests/AniDbDescriptionTests.cs
+++ b/Jellyfin.Plugin.AniDB.Tests/AniDbDescriptionTests.cs
@@ -1,0 +1,83 @@
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+using Xunit;
+
+namespace Jellyfin.Plugin.AniDB.Tests;
+
+/// <summary>
+/// Tests for the description AniDB writes being turned into the markup Jellyfin shows.
+/// </summary>
+public class AniDbDescriptionTests
+{
+    /// <summary>
+    /// The tags issue #87 is about. AniDB puts the note saying where a description came from in
+    /// italics, and both marks were being shown as written.
+    /// </summary>
+    [Fact]
+    public void ItalicsBecomeMarkup()
+        => Assert.Equal(
+            "Source: Crunchyroll<i>Note: an early screening.</i>",
+            AniDbDescription.ConvertMarkup("Source: Crunchyroll[i]Note: an early screening.[/i]"));
+
+    /// <summary>
+    /// The other tags with a counterpart.
+    /// </summary>
+    /// <param name="text">The description as AniDB wrote it.</param>
+    /// <param name="expected">The markup it becomes.</param>
+    [Theory]
+    [InlineData("[b]bold[/b]", "<b>bold</b>")]
+    [InlineData("[u]underlined[/u]", "<u>underlined</u>")]
+    [InlineData("[s]struck[/s]", "<s>struck</s>")]
+    [InlineData("[I]shouted[/I]", "<i>shouted</i>")]
+    public void KnownTagsBecomeMarkup(string text, string expected)
+        => Assert.Equal(expected, AniDbDescription.ConvertMarkup(text));
+
+    /// <summary>
+    /// A tag with no counterpart is removed and what it wrapped is kept.
+    /// </summary>
+    [Fact]
+    public void UnrenderableTagsAreRemoved()
+        => Assert.Equal(
+            "see the sequel",
+            AniDbDescription.ConvertMarkup("[url=https://anidb.net/anime/1]see the sequel[/url]"));
+
+    /// <summary>
+    /// A tag left open would run to the end of the description, so it is dropped rather than
+    /// turned into an element nothing closes.
+    /// </summary>
+    [Fact]
+    public void UnbalancedTagsAreRemoved()
+        => Assert.Equal("half italic", AniDbDescription.ConvertMarkup("[i]half italic"));
+
+    /// <summary>
+    /// Square brackets are not markup on their own. A description carries them in its own text,
+    /// and AniDB's link syntax writes the name of what it points at in them.
+    /// </summary>
+    /// <param name="text">The description as AniDB wrote it.</param>
+    [Theory]
+    [InlineData("an aside [see the sequel] written out")]
+    [InlineData("[Note] this is not a tag")]
+    [InlineData("no markup at all")]
+    public void OrdinaryBracketsAreLeftAlone(string text)
+        => Assert.Equal(text, AniDbDescription.ConvertMarkup(text));
+
+    /// <summary>
+    /// AniDB writes a link as the URL followed by the name in brackets. Only the name is worth
+    /// reading: the URL leads back to AniDB.
+    /// </summary>
+    [Fact]
+    public void LinksBecomeTheNameTheyCarry()
+        => Assert.Equal(
+            "adapted from Yuru Camp, which aired later",
+            AniDbDescription.StripLinks("adapted from https://anidb.net/anime/13043 [Yuru Camp], which aired later"));
+
+    /// <summary>
+    /// Every way a line can end becomes a line break, not only the one AniDB usually writes.
+    /// </summary>
+    /// <param name="text">The description as AniDB wrote it.</param>
+    [Theory]
+    [InlineData("one\ntwo")]
+    [InlineData("one\r\ntwo")]
+    [InlineData("one\rtwo")]
+    public void EveryLineEndingBecomesABreak(string text)
+        => Assert.Equal("one<br>two", AniDbDescription.ReplaceNewLine(text));
+}

--- a/Jellyfin.Plugin.AniDB.Tests/AniDbEpisodeKindTests.cs
+++ b/Jellyfin.Plugin.AniDB.Tests/AniDbEpisodeKindTests.cs
@@ -1,0 +1,54 @@
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+using Xunit;
+
+namespace Jellyfin.Plugin.AniDB.Tests;
+
+/// <summary>
+/// Tests for AniDB's episode numberings, which is what tells a special from a creditless
+/// opening from an ordinary episode.
+/// </summary>
+public class AniDbEpisodeKindTests
+{
+    /// <summary>
+    /// The prefix and the kind name each other, which is what lets a cached document be found
+    /// from a kind and read back into one.
+    /// </summary>
+    /// <param name="kind">The kind.</param>
+    /// <param name="prefix">The prefix AniDB writes before the number.</param>
+    [Theory]
+    [InlineData(AniDbEpisodeKind.Regular, "")]
+    [InlineData(AniDbEpisodeKind.Special, "S")]
+    [InlineData(AniDbEpisodeKind.Other, "O")]
+    [InlineData(AniDbEpisodeKind.Credits, "C")]
+    [InlineData(AniDbEpisodeKind.Trailer, "T")]
+    [InlineData(AniDbEpisodeKind.Parody, "P")]
+    internal void PrefixAndKindAgree(AniDbEpisodeKind kind, string prefix)
+    {
+        Assert.Equal(prefix, kind.Prefix());
+        Assert.Equal(kind, AniDbEpisodeKindExtensions.FromPrefix(prefix));
+    }
+
+    /// <summary>
+    /// A prefix AniDB does not use names no kind, rather than being read as an ordinary episode.
+    /// </summary>
+    [Fact]
+    public void AnUnknownPrefixNamesNothing()
+        => Assert.Null(AniDbEpisodeKindExtensions.FromPrefix("X"));
+
+    /// <summary>
+    /// Everything the library can only file among its specials, and nothing else. An ordinary
+    /// episode is not one, and neither is AniDB's other numbering, which holds the broadcast run
+    /// of something released another way and belongs in an ordinary season.
+    /// </summary>
+    /// <param name="kind">The kind.</param>
+    /// <param name="expected">Whether the library files it among its specials.</param>
+    [Theory]
+    [InlineData(AniDbEpisodeKind.Regular, false)]
+    [InlineData(AniDbEpisodeKind.Other, false)]
+    [InlineData(AniDbEpisodeKind.Special, true)]
+    [InlineData(AniDbEpisodeKind.Credits, true)]
+    [InlineData(AniDbEpisodeKind.Trailer, true)]
+    [InlineData(AniDbEpisodeKind.Parody, true)]
+    internal void OnlyTheExtrasAreFiledAmongTheSpecials(AniDbEpisodeKind kind, bool expected)
+        => Assert.Equal(expected, kind.IsExtra());
+}

--- a/Jellyfin.Plugin.AniDB.Tests/FuzzyMatchingTests.cs
+++ b/Jellyfin.Plugin.AniDB.Tests/FuzzyMatchingTests.cs
@@ -1,0 +1,116 @@
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.AniDB.Providers;
+using Xunit;
+
+namespace Jellyfin.Plugin.AniDB.Tests;
+
+/// <summary>
+/// Tests for the fuzzy name matching the titles file is searched with.
+/// </summary>
+public class FuzzyMatchingTests
+{
+    /// <summary>
+    /// The pattern matches the name it was built from. Everything else here is a way of
+    /// spelling a name differently, so this is the floor under all of it.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    [Theory]
+    [InlineData("Cowboy Bebop")]
+    [InlineData("Naruto")]
+    [InlineData("Fullmetal Alchemist: Brotherhood")]
+    [InlineData("K-On!")]
+    [InlineData("Re:Zero kara Hajimeru Isekai Seikatsu")]
+    [InlineData("Mahoutsukai no Yome")]
+    [InlineData("Bakemonogatari")]
+    [InlineData("5 Centimeters per Second")]
+    public void PatternMatchesItsOwnName(string name)
+        => Assert.Matches(Pattern(name), name);
+
+    /// <summary>
+    /// The spellings the equivalences exist for are matched by each other's pattern.
+    /// </summary>
+    /// <param name="name">The name as the library spells it.</param>
+    /// <param name="title">The name as AniDB spells it.</param>
+    [Theory]
+    [InlineData("Higurashi OVA", "Higurashi OAD")]
+    [InlineData("Higurashi OAD", "Higurashi OVA")]
+    [InlineData("Cardcaptor Sakura", "Kardkaptor Sakura")]
+    [InlineData("Fate and Stay", "Fate & Stay")]
+    [InlineData("Fate & Stay", "Fate and Stay")]
+    [InlineData("Gekijyouban Fate", "Gekijouban Fate")]
+    [InlineData("Gekijouban Fate", "Gekijyouban Fate")]
+    [InlineData("Mahoutsukai no Yome", "Mahou Tsukai no Yome")]
+    [InlineData("To Aru Majutsu no Index", "Toaru Majutsu no Index")]
+    [InlineData("Shingeki no Kyojin", "Shingeki no Kyojin")]
+    [InlineData("Kimi no Na wa.", "Kimi no Na wa")]
+    [InlineData("Steins;Gate", "Steins Gate")]
+    [InlineData("Jun`ichi", "Junichi")]
+    public void PatternMatchesTheOtherSpelling(string name, string title)
+        => Assert.Matches(Pattern(name), title);
+
+    /// <summary>
+    /// The rewrite exists because these two rules did not work. "OVA" nested one inside the
+    /// other, and the ampersand rule never fired because the rule before it had already
+    /// rewritten every n.
+    /// </summary>
+    [Fact]
+    public void EquivalencesAreNotAppliedToEachOthersOutput()
+    {
+        Assert.Equal("(?:ova|oad)", Equals_check.FuzzyRegexEscape("OVA"));
+        Assert.Equal("(?:&|and)", Equals_check.FuzzyRegexEscape("and"));
+        Assert.Equal("[ck]", Equals_check.FuzzyRegexEscape("c"));
+        Assert.Equal("[ck]", Equals_check.FuzzyRegexEscape("k"));
+    }
+
+    /// <summary>
+    /// A name that is not the same name is not matched. A pattern that matches everything would
+    /// pass every test above and be worth nothing.
+    /// </summary>
+    /// <param name="name">The name searched for.</param>
+    /// <param name="other">A title that is a different show.</param>
+    [Theory]
+    [InlineData("Cowboy Bebop", "Trigun")]
+    [InlineData("Naruto", "Bleach")]
+    [InlineData("Monster", "Steins;Gate")]
+    [InlineData("Clannad", "Air")]
+    public void PatternDoesNotMatchAnotherShow(string name, string other)
+        => Assert.DoesNotMatch(Pattern(name), other);
+
+    /// <summary>
+    /// The pattern is a valid regular expression whatever is put through it, punctuation that
+    /// means something to a regex engine included.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    [Theory]
+    [InlineData("[C]")]
+    [InlineData("Re:Zero")]
+    [InlineData("K-On!")]
+    [InlineData("Gochuumon wa Usagi desu ka??")]
+    [InlineData("+Tic Nee-san")]
+    [InlineData("(Not) a show")]
+    [InlineData("^$|*+")]
+    [InlineData("")]
+    public void PatternIsValid(string name)
+        => Assert.NotNull(new Regex(Equals_check.FuzzyRegexEscape(name), RegexOptions.IgnoreCase));
+
+    /// <summary>
+    /// The search shortens a name before making a pattern of it, so that a title carrying a
+    /// suffix AniDB does not use still matches.
+    /// </summary>
+    [Fact]
+    public void ShortenStringCutsTheGivenShare()
+    {
+        Assert.Equal("Cowboy Be", Equals_check.ShortenString("Cowboy Bebop", 6, 20));
+        Assert.Equal("Cowboy", Equals_check.ShortenString("Cowboy Bebop", 6, 90));
+        Assert.Equal("Air", Equals_check.ShortenString("Air", 6, 20));
+        Assert.Equal(string.Empty, Equals_check.ShortenString(string.Empty));
+    }
+
+    /// <summary>
+    /// The pattern as the search itself builds and uses it, which is without regard to case.
+    /// </summary>
+    /// <param name="name">The name to build a pattern from.</param>
+    /// <returns>The compiled pattern.</returns>
+    private static Regex Pattern(string name)
+        => new(Equals_check.FuzzyRegexEscape(name), RegexOptions.IgnoreCase);
+}

--- a/Jellyfin.Plugin.AniDB.Tests/Jellyfin.Plugin.AniDB.Tests.csproj
+++ b/Jellyfin.Plugin.AniDB.Tests/Jellyfin.Plugin.AniDB.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Jellyfin.Plugin.AniDB.Tests</RootNamespace>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+
+    <!-- xunit.v3 is a Microsoft.Testing.Platform runner: the test assembly hosts itself
+         rather than being loaded by one. `dotnet test` is pointed at that runner by the
+         global.json beside the solution. -->
+    <OutputType>Exe</OutputType>
+
+    <!-- The plugin turns every analyser on and treats warnings as errors. The tests are held
+         to the compiler's own rules, but not to the documentation and naming rules meant for
+         shipped code: a test method's name is its description. -->
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Jellyfin.Plugin.AniDB\Jellyfin.Plugin.AniDB.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Jellyfin.Plugin.AniDB.Tests/MovieKeyTests.cs
+++ b/Jellyfin.Plugin.AniDB.Tests/MovieKeyTests.cs
@@ -1,0 +1,68 @@
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+using Xunit;
+
+namespace Jellyfin.Plugin.AniDB.Tests;
+
+/// <summary>
+/// Tests for the key every mapping source files a movie under, whatever each of them calls it.
+/// </summary>
+public class MovieKeyTests
+{
+    /// <summary>
+    /// An id each source writes differently comes out as one key.
+    /// </summary>
+    [Fact]
+    public void OneMovieHasOneKeyAcrossTheSources()
+    {
+        Assert.Equal(MovieKey.Tmdb("128"), MovieKey.FromDescriptor("tmdb_movie:128"));
+        Assert.Equal(MovieKey.Imdb("tt0245429"), MovieKey.FromDescriptor("imdb_movie:tt0245429"));
+        Assert.Equal(MovieKey.Tvdb("42"), MovieKey.FromDescriptor("tvdb_movie:42"));
+    }
+
+    /// <summary>
+    /// A provider writing the IMDb prefix in capitals is writing the same id.
+    /// </summary>
+    [Fact]
+    public void ImdbIdsAreKeyedWithoutRegardToCase()
+        => Assert.Equal(MovieKey.Imdb("tt0245429"), MovieKey.Imdb("TT0245429"));
+
+    /// <summary>
+    /// Anything that is not an id is not a key, so that nothing is ever looked up under one.
+    /// </summary>
+    /// <param name="id">The value a source wrote where an id was expected.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("unknown")]
+    [InlineData("12a")]
+    public void SomethingThatIsNotAnIdIsNotAKey(string? id)
+    {
+        Assert.Null(MovieKey.Tmdb(id));
+        Assert.Null(MovieKey.Tvdb(id));
+        Assert.Null(MovieKey.Imdb(id));
+    }
+
+    /// <summary>
+    /// A key taken apart names the provider and the id it was made from, which is what has to
+    /// happen before a movie found by looking it up can be written back onto an item.
+    /// </summary>
+    [Fact]
+    public void AKeyIsTakenApartIntoWhatItWasMadeFrom()
+    {
+        Assert.Equal(("tmdb", "128"), MovieKey.Split(MovieKey.Tmdb("128")!));
+        Assert.Equal(("imdb", "tt0245429"), MovieKey.Split(MovieKey.Imdb("tt0245429")!));
+        Assert.Equal(("tvdb", "42"), MovieKey.Split(MovieKey.Tvdb("42")!));
+    }
+
+    /// <summary>
+    /// Something that is not a key is not taken apart into a provider and an id.
+    /// </summary>
+    /// <param name="key">The value to try.</param>
+    [Theory]
+    [InlineData("")]
+    [InlineData("tmdb")]
+    [InlineData(":128")]
+    [InlineData("tmdb:")]
+    public void SomethingThatIsNotAKeyIsNotTakenApart(string key)
+        => Assert.Null(MovieKey.Split(key));
+}

--- a/Jellyfin.Plugin.AniDB.Tests/Smoke.cs
+++ b/Jellyfin.Plugin.AniDB.Tests/Smoke.cs
@@ -1,0 +1,16 @@
+using Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+using Xunit;
+
+namespace Jellyfin.Plugin.AniDB.Tests;
+
+public class Smoke
+{
+    [Fact]
+    public void InternalsAreVisible() => Assert.Equal("tmdb:1", MovieKey.Tmdb("1"));
+
+    [Fact]
+    public void SkipWorks()
+    {
+        Assert.Skip("dynamic skip is available");
+    }
+}

--- a/Jellyfin.Plugin.AniDB.slnx
+++ b/Jellyfin.Plugin.AniDB.slnx
@@ -1,3 +1,4 @@
 <Solution>
+  <Project Path="Jellyfin.Plugin.AniDB.Tests/Jellyfin.Plugin.AniDB.Tests.csproj" />
   <Project Path="Jellyfin.Plugin.AniDB/Jellyfin.Plugin.AniDB.csproj" />
 </Solution>

--- a/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
@@ -75,6 +75,7 @@ public class PluginConfiguration : BasePluginConfiguration
         TagBlacklist = string.Empty;
         UseAniBridgeMappings = true;
         ImportCommunityRating = true;
+        PublishMappedIds = false;
         CastShowsCharacters = false;
     }
 
@@ -109,6 +110,15 @@ public class PluginConfiguration : BasePluginConfiguration
     /// wanting none, has to turn this off rather than choose between them.
     /// </summary>
     public bool ImportCommunityRating { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the TVDB and TMDB ids the mapping sources file a
+    /// show under are written onto it. They are what the image providers of those sites, and
+    /// fanart, are keyed by, so filling them in is what lets those fetch artwork for a show this
+    /// plugin identified. Off by default: the id also arms the metadata providers of those sites
+    /// where they are enabled. An id already set is never replaced.
+    /// </summary>
+    public bool PublishMappedIds { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the cast lists the characters rather than the

--- a/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
@@ -75,6 +75,7 @@ public class PluginConfiguration : BasePluginConfiguration
         TagBlacklist = string.Empty;
         UseAniBridgeMappings = true;
         ImportCommunityRating = true;
+        CastShowsCharacters = false;
     }
 
     /// <summary>
@@ -108,6 +109,14 @@ public class PluginConfiguration : BasePluginConfiguration
     /// wanting none, has to turn this off rather than choose between them.
     /// </summary>
     public bool ImportCommunityRating { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the cast lists the characters rather than the
+    /// actors voicing them, each named after the character and credited with its actor. AniDB
+    /// records both, and Jellyfin has no kind of its own for a character, so it is one or the
+    /// other.
+    /// </summary>
+    public bool CastShowsCharacters { get; set; }
 
     public bool TidyGenreList { get; set; }
 

--- a/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AniDB/Configuration/PluginConfiguration.cs
@@ -74,6 +74,7 @@ public class PluginConfiguration : BasePluginConfiguration
         InfoboxTagsOnly = false;
         TagBlacklist = string.Empty;
         UseAniBridgeMappings = true;
+        ImportCommunityRating = true;
     }
 
     /// <summary>
@@ -100,6 +101,13 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <see cref="ImportGenres"/>.
     /// </summary>
     public bool ImportTags { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether AniDB's rating is kept. Jellyfin holds one rating
+    /// per item rather than one per provider, so a library taking ratings from somewhere else, or
+    /// wanting none, has to turn this off rather than choose between them.
+    /// </summary>
+    public bool ImportCommunityRating { get; set; }
 
     public bool TidyGenreList { get; set; }
 

--- a/Jellyfin.Plugin.AniDB/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniDB/Configuration/configPage.html
@@ -117,6 +117,13 @@
                             </label>
                             <div class="fieldDescription">Uncheck to take no rating from AniDB, for a library that would rather have another provider's or none at all. Jellyfin holds one rating per item rather than one per provider, so this is a choice between them rather than a way of hiding one.</div>
                         </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkCastShowsCharacters" name="chkCastShowsCharacters" type="checkbox" is="emby-checkbox" />
+                                <span>List characters rather than voice actors</span>
+                            </label>
+                            <div class="fieldDescription">AniDB records both the characters and the actors voicing them, and Jellyfin has one credit for the two. Leave unchecked for the usual cast list, each actor credited with the character they play. Check to list the characters instead, each named after the character, pictured as the character and credited with its actor.</div>
+                        </div>
                         <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>
                             <input id="chkMaxGenres" name="chkMaxGenres" type="number" is="emby-input" min="0" />
@@ -335,6 +342,7 @@
                             document.getElementById('chkImportGenres').checked = config.ImportGenres;
                             document.getElementById('chkImportTags').checked = config.ImportTags;
                             document.getElementById('chkImportCommunityRating').checked = config.ImportCommunityRating;
+                            document.getElementById('chkCastShowsCharacters').checked = config.CastShowsCharacters;
                             document.getElementById('chkTitleSimilarityThreshold').value = config.TitleSimilarityThreshold;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
                             document.getElementById('chkTitleCaseGenres').checked = config.TitleCaseGenres;
@@ -363,6 +371,7 @@
                             config.ImportGenres = document.getElementById('chkImportGenres').checked;
                             config.ImportTags = document.getElementById('chkImportTags').checked;
                             config.ImportCommunityRating = document.getElementById('chkImportCommunityRating').checked;
+                            config.CastShowsCharacters = document.getElementById('chkCastShowsCharacters').checked;
                             config.TitleSimilarityThreshold = document.getElementById('chkTitleSimilarityThreshold').value;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
                             config.TitleCaseGenres = document.getElementById('chkTitleCaseGenres').checked;

--- a/Jellyfin.Plugin.AniDB/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniDB/Configuration/configPage.html
@@ -124,6 +124,13 @@
                             </label>
                             <div class="fieldDescription">AniDB records both the characters and the actors voicing them, and Jellyfin has one credit for the two. Leave unchecked for the usual cast list, each actor credited with the character they play. Check to list the characters instead, each named after the character, pictured as the character and credited with its actor.</div>
                         </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkPublishMappedIds" name="chkPublishMappedIds" type="checkbox" is="emby-checkbox" />
+                                <span>Fill in TVDB and TMDB ids</span>
+                            </label>
+                            <div class="fieldDescription">The mapping sources record which TVDB and TMDB entry each anime belongs to. Check to write those ids onto a show or film identified here, which is what lets the artwork providers keyed by them - TheTVDB, TMDB and fanart - fetch banners, backdrops and logos that AniDB does not carry. Off by default: on a server where those metadata providers are also enabled, an id fills them in as well. An id already set, by hand or by another provider, is never replaced.</div>
+                        </div>
                         <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>
                             <input id="chkMaxGenres" name="chkMaxGenres" type="number" is="emby-input" min="0" />
@@ -343,6 +350,7 @@
                             document.getElementById('chkImportTags').checked = config.ImportTags;
                             document.getElementById('chkImportCommunityRating').checked = config.ImportCommunityRating;
                             document.getElementById('chkCastShowsCharacters').checked = config.CastShowsCharacters;
+                            document.getElementById('chkPublishMappedIds').checked = config.PublishMappedIds;
                             document.getElementById('chkTitleSimilarityThreshold').value = config.TitleSimilarityThreshold;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
                             document.getElementById('chkTitleCaseGenres').checked = config.TitleCaseGenres;
@@ -372,6 +380,7 @@
                             config.ImportTags = document.getElementById('chkImportTags').checked;
                             config.ImportCommunityRating = document.getElementById('chkImportCommunityRating').checked;
                             config.CastShowsCharacters = document.getElementById('chkCastShowsCharacters').checked;
+                            config.PublishMappedIds = document.getElementById('chkPublishMappedIds').checked;
                             config.TitleSimilarityThreshold = document.getElementById('chkTitleSimilarityThreshold').value;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
                             config.TitleCaseGenres = document.getElementById('chkTitleCaseGenres').checked;

--- a/Jellyfin.Plugin.AniDB/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AniDB/Configuration/configPage.html
@@ -110,6 +110,13 @@
                             </label>
                             <div class="fieldDescription">Uncheck to take no tags from AniDB. Independent of the genres above: a library can have AniDB's tags without its genres, or the other way round.</div>
                         </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="chkImportCommunityRating" name="chkImportCommunityRating" type="checkbox" is="emby-checkbox" />
+                                <span>Import Ratings</span>
+                            </label>
+                            <div class="fieldDescription">Uncheck to take no rating from AniDB, for a library that would rather have another provider's or none at all. Jellyfin holds one rating per item rather than one per provider, so this is a choice between them rather than a way of hiding one.</div>
+                        </div>
                         <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>
                             <input id="chkMaxGenres" name="chkMaxGenres" type="number" is="emby-input" min="0" />
@@ -327,6 +334,7 @@
                             document.getElementById('chkUseAniDbSeasonNames').checked = config.UseAniDbSeasonNames;
                             document.getElementById('chkImportGenres').checked = config.ImportGenres;
                             document.getElementById('chkImportTags').checked = config.ImportTags;
+                            document.getElementById('chkImportCommunityRating').checked = config.ImportCommunityRating;
                             document.getElementById('chkTitleSimilarityThreshold').value = config.TitleSimilarityThreshold;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
                             document.getElementById('chkTitleCaseGenres').checked = config.TitleCaseGenres;
@@ -354,6 +362,7 @@
                             config.UseAniDbSeasonNames = document.getElementById('chkUseAniDbSeasonNames').checked;
                             config.ImportGenres = document.getElementById('chkImportGenres').checked;
                             config.ImportTags = document.getElementById('chkImportTags').checked;
+                            config.ImportCommunityRating = document.getElementById('chkImportCommunityRating').checked;
                             config.TitleSimilarityThreshold = document.getElementById('chkTitleSimilarityThreshold').value;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
                             config.TitleCaseGenres = document.getElementById('chkTitleCaseGenres').checked;

--- a/Jellyfin.Plugin.AniDB/Jellyfin.Plugin.AniDB.csproj
+++ b/Jellyfin.Plugin.AniDB/Jellyfin.Plugin.AniDB.csproj
@@ -21,6 +21,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Nearly everything the mapping and placement logic is made of is internal, that being
+         the right visibility for it: none of it is part of the plugin's surface. The tests
+         exercise it directly rather than only through the providers, which would need a
+         running server to reach. -->
+    <InternalsVisibleTo Include="Jellyfin.Plugin.AniDB.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="Configuration\configPage.html" />
     <EmbeddedResource Include="Configuration\configPage.html" />
   </ItemGroup>

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeIndex.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeIndex.cs
@@ -31,17 +31,26 @@ internal sealed class AniBridgeIndex
     private readonly IReadOnlyDictionary<string, IReadOnlyList<AniBridgeEntry>> _bySeries;
     private readonly IReadOnlyDictionary<string, string> _firstSeasonByTmdb;
     private readonly IReadOnlyDictionary<string, AniDbAnimeListEpisode> _movies;
+    private readonly IReadOnlyDictionary<string, string> _tmdbByAnimeId;
+    private readonly IReadOnlyDictionary<AniDbAnimeListEpisode, IReadOnlyList<string>> _movieKeys;
+    private readonly IReadOnlyDictionary<string, AniDbAnimeListEpisode> _soleMovieByAnimeId;
 
     private AniBridgeIndex(
         IReadOnlyDictionary<string, AniBridgeEntry> byAnimeId,
         IReadOnlyDictionary<string, IReadOnlyList<AniBridgeEntry>> bySeries,
         IReadOnlyDictionary<string, string> firstSeasonByTmdb,
-        IReadOnlyDictionary<string, AniDbAnimeListEpisode> movies)
+        IReadOnlyDictionary<string, AniDbAnimeListEpisode> movies,
+        IReadOnlyDictionary<string, string> tmdbByAnimeId,
+        IReadOnlyDictionary<AniDbAnimeListEpisode, IReadOnlyList<string>> movieKeys,
+        IReadOnlyDictionary<string, AniDbAnimeListEpisode> soleMovieByAnimeId)
     {
         _byAnimeId = byAnimeId;
         _bySeries = bySeries;
         _firstSeasonByTmdb = firstSeasonByTmdb;
         _movies = movies;
+        _tmdbByAnimeId = tmdbByAnimeId;
+        _movieKeys = movieKeys;
+        _soleMovieByAnimeId = soleMovieByAnimeId;
     }
 
     /// <summary>
@@ -182,6 +191,31 @@ internal sealed class AniBridgeIndex
     /// <returns>The TVDB id, or <c>null</c> where the mappings do not place that entry.</returns>
     public string? SeriesKeyOf(string animeId)
         => _byAnimeId.TryGetValue(animeId, out var entry) ? entry.SeriesKey : null;
+
+    /// <summary>
+    /// The TMDB show an entry is placed against, where the mappings place it against one. Not
+    /// every show they place has a TMDB id; the TVDB id is what they are keyed by.
+    /// </summary>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <returns>The TMDB show id, or <c>null</c> where the mappings name none for that entry.</returns>
+    public string? TmdbShowOf(string animeId)
+        => _tmdbByAnimeId.GetValueOrDefault(animeId);
+
+    /// <summary>
+    /// Every key the mappings file a movie under, given the AniDB episode it is. Answers for an
+    /// entry whose episode is not known only where the entry holds a single movie.
+    /// </summary>
+    /// <param name="animeId">The AniDB id of the entry holding the movie.</param>
+    /// <param name="episode">Which of its episodes the movie is, where that is known.</param>
+    /// <returns>The keys, in no particular order, which is empty where the movie is not identified.</returns>
+    public IReadOnlyList<string> MovieKeysOf(string animeId, AniDbAnimeListEpisode? episode)
+    {
+        var wanted = episode ?? _soleMovieByAnimeId.GetValueOrDefault(animeId);
+
+        return wanted == null || !string.Equals(wanted.AnimeId, animeId, StringComparison.Ordinal)
+            ? []
+            : _movieKeys.GetValueOrDefault(wanted) ?? [];
+    }
 
     /// <summary>
     /// Works out which of a show's entries fill the given season, and which of their episodes
@@ -455,6 +489,7 @@ internal sealed class AniBridgeIndex
             StringComparer.Ordinal);
 
         var firstSeasonByTmdb = new Dictionary<string, string>(StringComparer.Ordinal);
+        var tmdbByAnimeId = new Dictionary<string, string>(StringComparer.Ordinal);
 
         foreach (var (tmdbId, claims) in tmdbCandidates)
         {
@@ -465,7 +500,45 @@ internal sealed class AniBridgeIndex
                 .First();
 
             firstSeasonByTmdb[tmdbId] = first.AnimeId;
+
+            foreach (var claim in claims)
+            {
+                // An entry placed against two TMDB shows keeps the lower of the two ids, so that
+                // what is written onto a show does not depend on the order the file was read in.
+                if (!tmdbByAnimeId.TryGetValue(claim.AnimeId, out var held) || NumericId(tmdbId) < NumericId(held))
+                {
+                    tmdbByAnimeId[claim.AnimeId] = tmdbId;
+                }
+            }
         }
+
+        var movieKeys = new Dictionary<AniDbAnimeListEpisode, List<string>>();
+        var moviesByAnimeId = new Dictionary<string, HashSet<AniDbAnimeListEpisode>>(StringComparer.Ordinal);
+
+        foreach (var (key, episode) in identifiedMovies)
+        {
+            if (!movieKeys.TryGetValue(episode, out var keys))
+            {
+                keys = [];
+                movieKeys[episode] = keys;
+            }
+
+            keys.Add(key);
+
+            if (!moviesByAnimeId.TryGetValue(episode.AnimeId, out var held))
+            {
+                held = [];
+                moviesByAnimeId[episode.AnimeId] = held;
+            }
+
+            held.Add(episode);
+        }
+
+        // Only the entries holding exactly one movie. An entry holding a trilogy is one AniDB id
+        // and three TMDB ids, and nothing but the episode says which of them a film is.
+        var soleMovieByAnimeId = moviesByAnimeId
+            .Where(pair => pair.Value.Count == 1)
+            .ToDictionary(pair => pair.Key, pair => pair.Value.First(), StringComparer.Ordinal);
 
         logger.LogInformation(
             "{Source}, last written on {WrittenAt} to schema {SchemaVersion}, place {EntryCount} AniDB entries across {SeriesCount} TVDB shows, identify {TmdbCount} TMDB shows and identify {MovieCount} movies",
@@ -481,7 +554,10 @@ internal sealed class AniBridgeIndex
             byAnimeId,
             bySeries.ToDictionary(pair => pair.Key, pair => (IReadOnlyList<AniBridgeEntry>)pair.Value, StringComparer.Ordinal),
             firstSeasonByTmdb,
-            identifiedMovies);
+            identifiedMovies,
+            tmdbByAnimeId,
+            movieKeys.ToDictionary(pair => pair.Key, pair => (IReadOnlyList<string>)pair.Value),
+            soleMovieByAnimeId);
     }
 
     private static string? ReadSchemaVersion(ref Utf8JsonReader reader)

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeMappings.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniBridgeMappings.cs
@@ -216,6 +216,46 @@ internal static class AniBridgeMappings
     }
 
     /// <summary>
+    /// The TMDB show an entry is placed against, where the mappings place it against one.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The TMDB show id, or <c>null</c> where the mappings name none.</returns>
+    public static async Task<string?> ResolveTmdbShow(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.TmdbShowOf(animeId);
+    }
+
+    /// <summary>
+    /// Every key the mappings file a movie under, given the AniDB entry and episode it is.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of the entry holding the movie.</param>
+    /// <param name="episode">Which of its episodes the movie is, where that is known.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The keys, which is empty where the mappings identify no such movie.</returns>
+    public static async Task<IReadOnlyList<string>> ResolveMovieKeys(
+        IApplicationPaths appPaths,
+        string animeId,
+        AniDbAnimeListEpisode? episode,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.MovieKeysOf(animeId, episode) ?? [];
+    }
+
+    /// <summary>
     /// The entry a show begins in, given an entry of it that the mappings file as a later
     /// season.
     /// </summary>

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeList.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeList.cs
@@ -166,6 +166,27 @@ internal static class AniDbAnimeList
     }
 
     /// <summary>
+    /// Every key the list files a movie under, given the AniDB entry and episode it is.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of the entry holding the movie.</param>
+    /// <param name="episode">Which of its episodes the movie is, where that is known.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The keys, which is empty where the list identifies no such movie.</returns>
+    public static async Task<IReadOnlyList<string>> ResolveMovieKeys(
+        IApplicationPaths appPaths,
+        string animeId,
+        AniDbAnimeListEpisode? episode,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.MovieKeysOf(animeId, episode) ?? [];
+    }
+
+    /// <summary>
     /// The entry a show begins in, given an entry of it that the list files as a later season.
     /// AniDB titles a second season "&lt;name&gt; (&lt;year&gt;)" as readily as it titles a
     /// remake that way, so a name match on a show whose seasons all aired in one year lands on

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeListIndex.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbAnimeListIndex.cs
@@ -146,6 +146,33 @@ internal sealed class AniDbAnimeListIndex
         => _byAnimeId.TryGetValue(animeId, out var entry) ? entry.SeriesKey : null;
 
     /// <summary>
+    /// Every key the list files a movie under, given the AniDB episode it is. Answers for an
+    /// entry whose episode is not known only where the entry holds a single movie: an entry
+    /// holding a trilogy is one AniDB id and three movie ids, and nothing but the episode says
+    /// which of them a film is.
+    /// </summary>
+    /// <param name="animeId">The AniDB id of the entry holding the movie.</param>
+    /// <param name="episode">Which of its episodes the movie is, where that is known.</param>
+    /// <returns>The keys, in no particular order, which is empty where the movie is not identified.</returns>
+    public IReadOnlyList<string> MovieKeysOf(string animeId, AniDbAnimeListEpisode? episode)
+    {
+        var held = _movies
+            .Where(pair => string.Equals(pair.Value.AnimeId, animeId, StringComparison.Ordinal))
+            .ToList();
+
+        if (held.Count == 0)
+        {
+            return [];
+        }
+
+        var wanted = episode ?? (held.DistinctBy(pair => pair.Value).Count() == 1 ? held[0].Value : null);
+
+        return wanted == null
+            ? []
+            : [.. held.Where(pair => pair.Value == wanted).Select(pair => pair.Key)];
+    }
+
+    /// <summary>
     /// The entry a show begins in, found from the TVDB id another provider has already settled
     /// on. The list keys its entries by TVDB id, so this identifies a show outright where
     /// matching on the name cannot: where AniDB spells the name differently, and where two

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbMappingOverrides.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbMappingOverrides.cs
@@ -180,6 +180,65 @@ internal static class AniDbMappingOverrides
     }
 
     /// <summary>
+    /// The show an entry is filed under, as the TVDB id its seasons are numbered against.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The TVDB id, or <c>null</c> where the file does not place the entry.</returns>
+    public static async Task<string?> ResolveSeriesKey(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.SeriesKeyOf(animeId);
+    }
+
+    /// <summary>
+    /// The TMDB show an entry is placed against, where the file places it against one.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The TMDB show id, or <c>null</c> where the file names none.</returns>
+    public static async Task<string?> ResolveTmdbShow(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.TmdbShowOf(animeId);
+    }
+
+    /// <summary>
+    /// Every key the file identifies a movie under, given the AniDB entry and episode it is.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of the entry holding the movie.</param>
+    /// <param name="episode">Which of its episodes the movie is, where that is known.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The keys, which is empty where the file identifies no such movie.</returns>
+    public static async Task<IReadOnlyList<string>> ResolveMovieKeys(
+        IApplicationPaths appPaths,
+        string animeId,
+        AniDbAnimeListEpisode? episode,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var index = await _cache.GetIndex(appPaths, logger, cancellationToken).ConfigureAwait(false);
+
+        return index?.MovieKeysOf(animeId, episode) ?? [];
+    }
+
+    /// <summary>
     /// The entry a show begins in, given an entry of it the file places as a later season.
     /// </summary>
     /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbMappings.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/AniDbMappings.cs
@@ -324,6 +324,119 @@ internal static class AniDbMappings
     }
 
     /// <summary>
+    /// The ids other providers know a show by, as the mapping sources file it. What the image
+    /// providers of those sites, and fanart, are keyed by, so this is what lets them fetch
+    /// artwork for a show identified here.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of an entry of the show.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The ids, each of which may be absent.</returns>
+    public static async Task<MappedIds> ResolveShowIds(
+        IApplicationPaths appPaths,
+        string animeId,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var tvdbId = await AniDbMappingOverrides.ResolveSeriesKey(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false)
+            ?? await AniBridgeMappings.ResolveSeriesKey(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false)
+            ?? await AniDbAnimeList.ResolveSeriesKey(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false);
+
+        // Only the overrides and AniBridge carry TMDB show ids; the anime list has them for
+        // movies alone.
+        var tmdbId = await AniDbMappingOverrides.ResolveTmdbShow(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false)
+            ?? await AniBridgeMappings.ResolveTmdbShow(appPaths, animeId, logger, cancellationToken).ConfigureAwait(false);
+
+        // A source keys a show the other site does not carry under a placeholder word rather
+        // than an id, and a placeholder written onto a show would send the other provider
+        // looking for a series that does not exist.
+        return new MappedIds(Numeric(tvdbId), Numeric(tmdbId), null);
+    }
+
+    /// <summary>
+    /// The ids other providers know a movie by, as the mapping sources file it. The sources are
+    /// asked in their own order and the first to identify the movie answers with every id it
+    /// holds for it, rather than each id being taken from whichever source has one: two sources
+    /// disagreeing about what a film is would otherwise be written onto it together.
+    /// </summary>
+    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="animeId">The AniDB id of the entry holding the movie.</param>
+    /// <param name="episode">Which of its episodes the movie is, where that is known.</param>
+    /// <param name="logger">The logger of whichever provider is asking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The ids, each of which may be absent.</returns>
+    public static async Task<MappedIds> ResolveMovieIds(
+        IApplicationPaths appPaths,
+        string animeId,
+        AniDbAnimeListEpisode? episode,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        Func<Task<IReadOnlyList<string>>>[] sources =
+        [
+            () => AniDbMappingOverrides.ResolveMovieKeys(appPaths, animeId, episode, logger, cancellationToken),
+            () => AniBridgeMappings.ResolveMovieKeys(appPaths, animeId, episode, logger, cancellationToken),
+            () => AniDbAnimeList.ResolveMovieKeys(appPaths, animeId, episode, logger, cancellationToken),
+        ];
+
+        foreach (var source in sources)
+        {
+            var keys = await source().ConfigureAwait(false);
+
+            if (keys.Count == 0)
+            {
+                continue;
+            }
+
+            string? tvdbId = null;
+            string? tmdbId = null;
+            string? imdbId = null;
+
+            foreach (var key in keys)
+            {
+                if (MovieKey.Split(key) is not { } parts)
+                {
+                    continue;
+                }
+
+                switch (parts.Provider)
+                {
+                    case "tvdb":
+                        tvdbId = parts.Id;
+                        break;
+
+                    case "tmdb":
+                        tmdbId = parts.Id;
+                        break;
+
+                    case "imdb":
+                        imdbId = parts.Id;
+                        break;
+                }
+            }
+
+            var found = new MappedIds(tvdbId, tmdbId, imdbId);
+
+            if (found.Any)
+            {
+                return found;
+            }
+        }
+
+        return MappedIds.None;
+    }
+
+    /// <summary>
+    /// An id as a provider would read it, which is nothing where a source wrote a placeholder
+    /// in place of one.
+    /// </summary>
+    /// <param name="id">The id as the source wrote it.</param>
+    /// <returns>The id, or <c>null</c> where it is not one.</returns>
+    private static string? Numeric(string? id)
+        => !string.IsNullOrEmpty(id) && id.All(char.IsAsciiDigit) ? id : null;
+
+    /// <summary>
     /// Notes a season the anime list places and AniBridge does not, for a show AniBridge places
     /// otherwise. One of the two is wrong about that show, and this is the only point at which
     /// a season is filled from a source other than the one that identified the show.

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappedIds.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MappedIds.cs
@@ -1,0 +1,22 @@
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Mapping;
+
+/// <summary>
+/// The ids other providers know an item by, as the mapping sources file it. What each means
+/// depends on the item: a show's TVDB id numbers a series, a movie's numbers a film, and TVDB
+/// numbers the two separately.
+/// </summary>
+/// <param name="Tvdb">The TVDB id, or <c>null</c> where no source names one.</param>
+/// <param name="Tmdb">The TMDB id, or <c>null</c> where no source names one.</param>
+/// <param name="Imdb">The IMDb id, or <c>null</c> where no source names one.</param>
+internal sealed record MappedIds(string? Tvdb, string? Tmdb, string? Imdb)
+{
+    /// <summary>
+    /// Nothing identified.
+    /// </summary>
+    public static readonly MappedIds None = new(null, null, null);
+
+    /// <summary>
+    /// Gets a value indicating whether any id was found.
+    /// </summary>
+    public bool Any => Tvdb != null || Tmdb != null || Imdb != null;
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MovieKey.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Mapping/MovieKey.cs
@@ -53,6 +53,21 @@ internal static class MovieKey
     }
 
     /// <summary>
+    /// The provider and id a key is made of, which is what a key found by looking a movie up
+    /// has to be taken apart into before it can be written back onto one.
+    /// </summary>
+    /// <param name="key">The key, as the other methods here write one.</param>
+    /// <returns>The two parts, or <c>null</c> where the key is not one of these.</returns>
+    public static (string Provider, string Id)? Split(string key)
+    {
+        var separator = key.IndexOf(':', StringComparison.Ordinal);
+
+        return separator <= 0 || separator == key.Length - 1
+            ? null
+            : (key[..separator], key[(separator + 1)..]);
+    }
+
+    /// <summary>
     /// The key an AniBridge movie descriptor names, which is "&lt;provider&gt;_movie:&lt;id&gt;".
     /// </summary>
     /// <param name="descriptor">The descriptor as written.</param>

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbDescription.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbDescription.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
+
+/// <summary>
+/// Turns a description as AniDB writes it into the markup Jellyfin shows.
+/// <para>
+/// AniDB writes a description as plain text with two things in it that mean nothing to a
+/// browser: its own link syntax, which names the entry it points at in square brackets after
+/// the URL, and a handful of BBCode tags, most often <c>[i]</c> around the note saying where
+/// the description came from.
+/// </para>
+/// </summary>
+internal static partial class AniDbDescription
+{
+    /// <summary>
+    /// The BBCode tags with an HTML counterpart, and the element each becomes. Every other tag
+    /// the pattern recognises is removed and its content kept.
+    /// </summary>
+    private static readonly Dictionary<string, string> _html = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["i"] = "i",
+        ["b"] = "b",
+        ["u"] = "u",
+        ["s"] = "s",
+    };
+
+    /// <summary>
+    /// Prepares a description for display: graves, links, markup and line breaks, in the one
+    /// order that works. Links are resolved before the markup, both being written in square
+    /// brackets, and the line breaks last, so nothing else has to preserve them.
+    /// </summary>
+    /// <param name="text">The description as AniDB wrote it.</param>
+    /// <returns>The description as Jellyfin shows it, which is empty where nothing was given.</returns>
+    public static string Clean(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var cleaned = Plugin.Instance.Configuration.AniDbReplaceGraves
+            ? text.Replace('`', '\'')
+            : text;
+
+        return ReplaceNewLine(ConvertMarkup(StripLinks(cleaned)));
+    }
+
+    /// <summary>
+    /// Replaces AniDB's links with the name they carry, that being the only part of one worth
+    /// reading: the URL leads back to AniDB rather than anywhere the reader can go from here.
+    /// </summary>
+    /// <param name="text">The text to transform.</param>
+    /// <returns>The transformed text.</returns>
+    public static string StripLinks(string text)
+    {
+        return AniDbUrlRegex().Replace(text, "${name}");
+    }
+
+    /// <summary>
+    /// Turns the BBCode tags AniDB uses into HTML, and removes the ones with nothing to turn
+    /// into. A tag whose opening and closing marks do not pair up is removed rather than
+    /// converted: an element left open would run to the end of the description.
+    /// </summary>
+    /// <param name="text">The text to transform.</param>
+    /// <returns>The transformed text.</returns>
+    public static string ConvertMarkup(string text)
+    {
+        var matches = MarkupRegex().Matches(text);
+
+        if (matches.Count == 0)
+        {
+            return text;
+        }
+
+        var balance = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (Match match in matches)
+        {
+            var tag = match.Groups["tag"].Value;
+
+            if (_html.ContainsKey(tag))
+            {
+                balance[tag] = balance.GetValueOrDefault(tag) + (match.Groups["close"].Length == 0 ? 1 : -1);
+            }
+        }
+
+        return MarkupRegex().Replace(
+            text,
+            match =>
+            {
+                var tag = match.Groups["tag"].Value;
+
+                return _html.TryGetValue(tag, out var element) && balance.GetValueOrDefault(tag) == 0
+                    ? FormattableString.Invariant($"<{match.Groups["close"].Value}{element}>")
+                    : string.Empty;
+            });
+    }
+
+    /// <summary>
+    /// Replaces new lines with HTML line breaks, however the line was ended.
+    /// </summary>
+    /// <param name="text">The text to transform.</param>
+    /// <returns>The transformed text.</returns>
+    public static string ReplaceNewLine(string text)
+    {
+        return NewLineRegex().Replace(text, "<br>");
+    }
+
+    [GeneratedRegex(@"https?://anidb.net/\w+(/[0-9]+)? \[(?<name>[^\]]*)\]")]
+    private static partial Regex AniDbUrlRegex();
+
+    /// <summary>
+    /// A BBCode tag, named rather than open ended: a description carries square brackets of its
+    /// own, and an aside written "[see the sequel]" is text rather than markup.
+    /// </summary>
+    /// <returns>The pattern.</returns>
+    [GeneratedRegex(@"\[(?<close>/?)(?<tag>i|b|u|s|url|code|spoiler|quote|center|color|size)(?:=[^\]]*)?\]", RegexOptions.IgnoreCase)]
+    private static partial Regex MarkupRegex();
+
+    [GeneratedRegex(@"\r\n|\r|\n")]
+    private static partial Regex NewLineRegex();
+}

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeKind.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeKind.cs
@@ -22,5 +22,21 @@ internal enum AniDbEpisodeKind
     /// broadcast as a run of television episodes is recorded twice: as the entry's ordinary
     /// episodes, one per movie, and again here, one per broadcast episode.
     /// </summary>
-    Other
+    Other,
+
+    /// <summary>
+    /// A creditless opening or ending, numbered from C1. AniDB files both under the one
+    /// numbering, telling them apart by title alone.
+    /// </summary>
+    Credits,
+
+    /// <summary>
+    /// A trailer, promotion or advertisement, numbered from T1.
+    /// </summary>
+    Trailer,
+
+    /// <summary>
+    /// A parody, numbered from P1.
+    /// </summary>
+    Parody
 }

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeKindExtensions.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeKindExtensions.cs
@@ -15,6 +15,43 @@ internal static class AniDbEpisodeKindExtensions
     {
         AniDbEpisodeKind.Special => "S",
         AniDbEpisodeKind.Other => "O",
+        AniDbEpisodeKind.Credits => "C",
+        AniDbEpisodeKind.Trailer => "T",
+        AniDbEpisodeKind.Parody => "P",
         _ => string.Empty,
     };
+
+    /// <summary>
+    /// The kind AniDB's prefix stands for, which is the ordinary numbering where there is none.
+    /// </summary>
+    /// <param name="prefix">The prefix, as it is written before an episode number.</param>
+    /// <returns>The kind, or <c>null</c> where the prefix is not one AniDB uses.</returns>
+    public static AniDbEpisodeKind? FromPrefix(string prefix) => prefix switch
+    {
+        "" => AniDbEpisodeKind.Regular,
+        "S" => AniDbEpisodeKind.Special,
+        "O" => AniDbEpisodeKind.Other,
+        "C" => AniDbEpisodeKind.Credits,
+        "T" => AniDbEpisodeKind.Trailer,
+        "P" => AniDbEpisodeKind.Parody,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Whether an episode of this kind is one the library can only have filed among its specials.
+    /// Jellyfin has one season for everything that is not an ordinary episode, so a special, a
+    /// creditless opening, a trailer and a parody all land there.
+    /// <para>
+    /// <see cref="AniDbEpisodeKind.Other"/> is not among them: it is where AniDB puts the
+    /// broadcast run of something released another way, which the mapping sources place into an
+    /// ordinary season rather than the specials.
+    /// </para>
+    /// </summary>
+    /// <param name="kind">The kind.</param>
+    /// <returns>Whether the library files it among its specials.</returns>
+    public static bool IsExtra(this AniDbEpisodeKind kind) => kind
+        is AniDbEpisodeKind.Special
+        or AniDbEpisodeKind.Credits
+        or AniDbEpisodeKind.Trailer
+        or AniDbEpisodeKind.Parody;
 }

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
@@ -656,8 +656,7 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
                         break;
 
                     case "summary":
-                        var overview = AniDbSeriesProvider.ReplaceNewLine(await reader.ReadElementContentAsStringAsync().ConfigureAwait(false));
-                        episode.Overview = Plugin.Instance.Configuration.AniDbReplaceGraves ? overview.Replace('`', '\'') : overview;
+                        episode.Overview = AniDbDescription.Clean(await reader.ReadElementContentAsStringAsync().ConfigureAwait(false));
 
                         break;
                 }

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
@@ -631,7 +631,8 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
                         break;
 
                     case "rating":
-                        if (int.TryParse(reader.GetAttribute("votes"), NumberStyles.Any, CultureInfo.InvariantCulture, out _))
+                        if (Plugin.Instance.Configuration.ImportCommunityRating
+                            && int.TryParse(reader.GetAttribute("votes"), NumberStyles.Any, CultureInfo.InvariantCulture, out _))
                         {
                             var ratingText = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
                             if (float.TryParse(ratingText, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var rating))

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
@@ -29,6 +29,18 @@ namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 /// <param name="logger">Instance of the <see cref="ILogger{AniDbEpisodeProvider}"/> interface.</param>
 public partial class AniDbEpisodeProvider(IServerConfigurationManager configurationManager, ILibraryManager libraryManager, ILogger<AniDbEpisodeProvider> logger) : IRemoteMetadataProvider<Episode, EpisodeInfo>
 {
+    /// <summary>
+    /// The numberings the library can only have filed among its specials, in the order a
+    /// specials season runs through them.
+    /// </summary>
+    private static readonly AniDbEpisodeKind[] _extraKinds =
+    [
+        AniDbEpisodeKind.Special,
+        AniDbEpisodeKind.Credits,
+        AniDbEpisodeKind.Trailer,
+        AniDbEpisodeKind.Parody,
+    ];
+
     private readonly IServerConfigurationManager _configurationManager = configurationManager;
     private readonly ILibraryManager _libraryManager = libraryManager;
     private readonly ILogger<AniDbEpisodeProvider> _logger = logger;
@@ -206,7 +218,7 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
         if (specials.Count == 0)
         {
             _logger.LogWarning(
-                "None of the {EntryCount} AniDB entries of series {SeriesId} has any special, so special {EpisodeNumber} stays without metadata",
+                "None of the {EntryCount} AniDB entries of series {SeriesId} has any special, creditless opening, trailer or parody, so special {EpisodeNumber} stays without metadata",
                 chain.Count,
                 seriesId,
                 info.IndexNumber);
@@ -220,17 +232,22 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
         // lines up with nothing, and numbering straight down the list would give every special
         // after the first difference the wrong entry.
         var libraryCount = AniDbSeasonLayout.Read(_libraryManager, seriesId)?.SpecialsCount;
-        var aligned = Align(specials, libraryCount);
+
+        // Counted through AniDB's specials alone. A library that holds the creditless openings
+        // too holds more than the specials season AniDB describes, and a library that holds none
+        // of them would be numbered off the end of its own season by a list padded with them.
+        var aligned = Align([.. specials.Where(special => special.Kind == AniDbEpisodeKind.Special)], libraryCount);
 
         var match = MatchById(specials, info)
             ?? MatchByTitle(specials, info)
+            ?? MatchByCreditsName(specials, info)
             ?? MatchByDate(specials, info)
             ?? (aligned == null ? null : MatchByPosition(aligned, info));
 
         if (match == null)
         {
             _logger.LogWarning(
-                "Special {EpisodeNumber} of AniDB series {SeriesId} matches none of the {SpecialCount} specials across its {EntryCount} AniDB entries by id, title or air date, so it stays without metadata. The library has {LibraryCount} specials, which line up with neither the whole of that list nor any single entry of it, so they cannot be numbered straight through. Set its AniDB id by hand to fill it in",
+                "Special {EpisodeNumber} of AniDB series {SeriesId} matches none of the {SpecialCount} specials, creditless openings, trailers and parodies across its {EntryCount} AniDB entries by id, title or air date, so it stays without metadata. The library has {LibraryCount} specials, which line up with neither the whole of that list nor any single entry of it, so they cannot be numbered straight through. Set its AniDB id by hand to fill it in",
                 info.IndexNumber,
                 seriesId,
                 specials.Count,
@@ -309,19 +326,34 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
 
             var inEntry = new List<AniDbSpecial>();
 
-            foreach (var path in Directory.EnumerateFiles(folder, "episode-S*.xml"))
+            // Asked for one numbering at a time so that the file system does the narrowing. An
+            // entry of a long running show holds a thousand ordinary episodes, and none of them
+            // is ever an answer here.
+            foreach (var kind in _extraKinds)
             {
-                var number = SpecialNumberRegex().Match(Path.GetFileName(path));
-                if (!number.Success || !int.TryParse(number.Groups[1].ValueSpan, CultureInfo.InvariantCulture, out var index))
-                {
-                    continue;
-                }
+                var prefix = kind.Prefix();
 
-                inEntry.Add(await ParseSpecial(path, animeId, index).ConfigureAwait(false));
+                foreach (var path in Directory.EnumerateFiles(folder, FormattableString.Invariant($"episode-{prefix}*.xml")))
+                {
+                    var number = SpecialNumberRegex().Match(Path.GetFileName(path));
+
+                    // The pattern is matched again rather than trusted to the glob, which on a
+                    // case insensitive file system answers for every other numbering too.
+                    if (!number.Success
+                        || !string.Equals(number.Groups[1].Value, prefix, StringComparison.Ordinal)
+                        || !int.TryParse(number.Groups[2].ValueSpan, CultureInfo.InvariantCulture, out var index))
+                    {
+                        continue;
+                    }
+
+                    inEntry.Add(await ParseSpecial(path, animeId, index, kind).ConfigureAwait(false));
+                }
             }
 
-            // Directory order is the file system's. AniDB's numbering is the real order.
-            specials.AddRange(inEntry.OrderBy(special => special.Number));
+            // Directory order is the file system's. AniDB's numbering is the real order, within
+            // each of its numberings; the specials come first, being what the library is likeliest
+            // to hold and what a season counted straight through is numbered by.
+            specials.AddRange(inEntry.OrderBy(special => special.Kind).ThenBy(special => special.Number));
         }
 
         return specials;
@@ -424,7 +456,7 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
         return Path.GetDirectoryName(seriesDataPath);
     }
 
-    private static async Task<AniDbSpecial> ParseSpecial(string path, string animeId, int number)
+    private static async Task<AniDbSpecial> ParseSpecial(string path, string animeId, int number, AniDbEpisodeKind kind)
     {
         var settings = new XmlReaderSettings
         {
@@ -478,7 +510,7 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
             }
         }
 
-        return new AniDbSpecial(animeId, path, number, episodeId, airDate, titles);
+        return new AniDbSpecial(animeId, path, number, episodeId, airDate, titles, kind);
     }
 
     /// <summary>
@@ -515,6 +547,45 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
 
         var matches = specials
             .Where(special => special.Titles.Any(title => string.Equals(Normalize(title), name, StringComparison.Ordinal)))
+            .ToList();
+
+        return matches.Count == 1 ? matches[0] : null;
+    }
+
+    /// <summary>
+    /// Matches a creditless opening or ending named the way a library names one rather than the
+    /// way AniDB titles it. AniDB calls them "Opening 1" and "Ending 2"; a library files them as
+    /// "OP1", "NCOP1", "ED2" or "NCED2", which no amount of normalising makes equal. Only an
+    /// unambiguous hit counts, so a numbering the titles do not settle matches nothing rather
+    /// than the wrong opening.
+    /// </summary>
+    /// <param name="specials">The specials to match against.</param>
+    /// <param name="info">The episode lookup info.</param>
+    /// <returns>The matching special, or <c>null</c>.</returns>
+    private static AniDbSpecial? MatchByCreditsName(IReadOnlyList<AniDbSpecial> specials, EpisodeInfo info)
+    {
+        if (string.IsNullOrWhiteSpace(info.Name))
+        {
+            return null;
+        }
+
+        var named = CreditsNameRegex().Match(info.Name.Trim());
+
+        if (!named.Success)
+        {
+            return null;
+        }
+
+        // AniDB titles both under the one numbering, so the word is the whole of the difference.
+        var wanted = named.Groups["kind"].Value.StartsWith('o') || named.Groups["kind"].Value.StartsWith('O')
+            ? "opening"
+            : "ending";
+
+        var ordinal = named.Groups["number"].Value;
+
+        var matches = specials
+            .Where(special => special.Kind == AniDbEpisodeKind.Credits
+                && special.Titles.Any(title => Normalize(title).Contains(wanted + ordinal, StringComparison.Ordinal)))
             .ToList();
 
         return matches.Count == 1 ? matches[0] : null;
@@ -691,8 +762,16 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
         return new FileInfo(filename);
     }
 
-    [GeneratedRegex(@"^episode-S(\d+)\.xml$")]
+    [GeneratedRegex(@"^episode-([A-Z]*)(\d+)\.xml$")]
     private static partial Regex SpecialNumberRegex();
+
+    /// <summary>
+    /// A name that says nothing but which creditless opening or ending this is. The trailing
+    /// letter is the one a second version of the same opening is given, as in "NCOP1b".
+    /// </summary>
+    /// <returns>The pattern.</returns>
+    [GeneratedRegex(@"^(?:nc|creditless[\s_-]*)?(?<kind>op(?:ening)?|ed|ending)[\s_-]*(?<number>\d*)[a-z]?$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex CreditsNameRegex();
 
     /// <summary>
     /// A special held by one AniDB entry.
@@ -703,11 +782,13 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
     /// <param name="EpisodeId">Its own AniDB episode id.</param>
     /// <param name="AirDate">The date it aired.</param>
     /// <param name="Titles">Every title AniDB records for it.</param>
+    /// <param name="Kind">Which of the entry's numberings it belongs to.</param>
     private sealed record AniDbSpecial(
         string AnimeId,
         string Path,
         int Number,
         string? EpisodeId,
         DateTime? AirDate,
-        IReadOnlyList<string> Titles);
+        IReadOnlyList<string> Titles,
+        AniDbEpisodeKind Kind);
 }

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbImageProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbImageProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -12,6 +13,7 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.AniDB.Providers.AniDB.Metadata;
 
@@ -29,7 +31,7 @@ public class AniDbImageProvider(IApplicationPaths appPaths) : IRemoteImageProvid
     /// <inheritdoc />
     public async Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
     {
-        await AniDbSeriesProvider.WaitForRequestSlot(cancellationToken).ConfigureAwait(false);
+        await AniDbSeriesProvider.WaitForImageSlot(cancellationToken).ConfigureAwait(false);
         var httpClient = Plugin.Instance.GetHttpClient();
 
         return await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
@@ -54,8 +56,24 @@ public class AniDbImageProvider(IApplicationPaths appPaths) : IRemoteImageProvid
 
         if (!string.IsNullOrEmpty(aniDbId))
         {
-            var seriesDataPath = await AniDbSeriesProvider.GetSeriesData(_appPaths, aniDbId, cancellationToken).ConfigureAwait(false);
-            var imageUrl = await FindImageUrl(seriesDataPath).ConfigureAwait(false);
+            string? imageUrl;
+
+            try
+            {
+                var seriesDataPath = await AniDbSeriesProvider.GetSeriesData(_appPaths, aniDbId, cancellationToken).ConfigureAwait(false);
+                imageUrl = await FindImageUrl(seriesDataPath).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is AniDbBannedException or IOException or XmlException or UnauthorizedAccessException)
+            {
+                // Nothing to offer rather than a failed refresh. The document is fetched again
+                // on the next one, and until then the item keeps whatever image it has.
+                AniDbSeriesProvider.Logger?.LogWarning(
+                    ex,
+                    "The cached document of AniDB anime {AnimeId} could not be read, so no image is offered for it",
+                    aniDbId);
+
+                return list;
+            }
 
             if (!string.IsNullOrEmpty(imageUrl))
             {

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbMovieProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbMovieProvider.cs
@@ -72,7 +72,9 @@ public class AniDbMovieProvider(IApplicationPaths appPaths, ILogger<AniDbMoviePr
 
         if (!string.IsNullOrEmpty(animeId))
         {
-            var seriesResult = await _seriesProvider.GetMetadataForId(animeId, seriesInfo, cancellationToken).ConfigureAwait(false);
+            // A movie is not the show whose entry may hold it, so the show's own TVDB and TMDB
+            // ids are not written onto it. Its own are added below.
+            var seriesResult = await _seriesProvider.GetMetadataForId(animeId, seriesInfo, cancellationToken, publishShowIds: false).ConfigureAwait(false);
 
             if (seriesResult.HasMetadata)
             {
@@ -96,6 +98,8 @@ public class AniDbMovieProvider(IApplicationPaths appPaths, ILogger<AniDbMoviePr
                     await ReadFromEpisode(movie, mapped, info.MetadataLanguage).ConfigureAwait(false);
                 }
 
+                await AddMappedMovieIds(movie, info, animeId, mapped?.Episode, cancellationToken).ConfigureAwait(false);
+
                 return new MetadataResult<Movie>
                 {
                     HasMetadata = true,
@@ -107,6 +111,48 @@ public class AniDbMovieProvider(IApplicationPaths appPaths, ILogger<AniDbMoviePr
         }
 
         return new MetadataResult<Movie>();
+    }
+
+    /// <summary>
+    /// Writes the ids the mapping sources file a film under onto it, where that is turned on.
+    /// Those sites' image providers are keyed by them, so this is what lets them fetch artwork
+    /// for a film AniDB identified.
+    /// </summary>
+    /// <param name="movie">The movie being filled in.</param>
+    /// <param name="info">The lookup info, holding whatever ids the item already carries.</param>
+    /// <param name="animeId">The AniDB id of the entry holding the film.</param>
+    /// <param name="episode">Which of its episodes the film is, where a source said so.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    private async Task AddMappedMovieIds(
+        Movie movie,
+        MovieInfo info,
+        string animeId,
+        AniDbAnimeListEpisode? episode,
+        CancellationToken cancellationToken)
+    {
+        if (!Plugin.Instance.Configuration.PublishMappedIds)
+        {
+            return;
+        }
+
+        var ids = await AniDbMappings.ResolveMovieIds(appPaths, animeId, episode, _logger, cancellationToken).ConfigureAwait(false);
+
+        if (!ids.Any)
+        {
+            return;
+        }
+
+        AniDbSeriesProvider.AddMappedId(movie, info.ProviderIds, nameof(MetadataProvider.Tvdb), ids.Tvdb);
+        AniDbSeriesProvider.AddMappedId(movie, info.ProviderIds, nameof(MetadataProvider.Tmdb), ids.Tmdb);
+        AniDbSeriesProvider.AddMappedId(movie, info.ProviderIds, nameof(MetadataProvider.Imdb), ids.Imdb);
+
+        _logger.LogDebug(
+            "{MovieName} is filed under TVDB {TvdbId}, TMDB {TmdbId} and IMDb {ImdbId}, which are written onto it so that whatever is keyed by them can fetch its artwork",
+            movie.Name,
+            ids.Tvdb,
+            ids.Tmdb,
+            ids.Imdb);
     }
 
     /// <inheritdoc />

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbPersonImageProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbPersonImageProvider.cs
@@ -55,7 +55,7 @@ public class AniDbPersonImageProvider(IApplicationPaths paths) : IRemoteImagePro
     /// <inheritdoc />
     public async Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
     {
-        await AniDbSeriesProvider.WaitForRequestSlot(cancellationToken).ConfigureAwait(false);
+        await AniDbSeriesProvider.WaitForImageSlot(cancellationToken).ConfigureAwait(false);
         var httpClient = Plugin.Instance.GetHttpClient();
 
         return await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -640,7 +640,7 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     /// <inheritdoc />
     public async Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
     {
-        await WaitForRequestSlot(cancellationToken).ConfigureAwait(false);
+        await WaitForImageSlot(cancellationToken).ConfigureAwait(false);
         var httpClient = Plugin.Instance.GetHttpClient();
 
         return await httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
@@ -743,9 +743,27 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    internal static async Task WaitForRequestSlot(CancellationToken cancellationToken)
+    internal static Task WaitForRequestSlot(CancellationToken cancellationToken)
+        => WaitForSlot(true, cancellationToken);
+
+    /// <summary>
+    /// Waits for the slot an image download takes. Images come from AniDB's image server rather
+    /// than from its API, which counts and bans separately, so a download waits its turn like
+    /// anything else but is not held back by a ban on the API. Otherwise a poster the API has
+    /// already described is lost for as long as the ban lasts, which is what leaves a show
+    /// identified during one without its artwork until someone picks it by hand.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    internal static Task WaitForImageSlot(CancellationToken cancellationToken)
+        => WaitForSlot(false, cancellationToken);
+
+    private static async Task WaitForSlot(bool countsAgainstTheApi, CancellationToken cancellationToken)
     {
-        ThrowIfBanned();
+        if (countsAgainstTheApi)
+        {
+            ThrowIfBanned();
+        }
 
         Interlocked.Increment(ref _queuedRequests);
 
@@ -763,7 +781,10 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                 }
 
                 // A caller ahead in the queue may have been banned while this one waited.
-                ThrowIfBanned();
+                if (countsAgainstTheApi)
+                {
+                    ThrowIfBanned();
+                }
 
                 _nextRequestTimestamp = Stopwatch.GetTimestamp() + GetRequestIntervalTicks();
 

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -483,8 +483,13 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     /// <param name="animeId">The AniDB id.</param>
     /// <param name="info">The series lookup info.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="publishShowIds">Whether the ids the mapping sources file the show under may be written onto the result. Off for a movie read out of a show's entry, which is not that show and must not carry the ids of its seasons.</param>
     /// <returns>The metadata result.</returns>
-    public async Task<MetadataResult<Series>> GetMetadataForId(string animeId, SeriesInfo info, CancellationToken cancellationToken)
+    public async Task<MetadataResult<Series>> GetMetadataForId(
+        string animeId,
+        SeriesInfo info,
+        CancellationToken cancellationToken,
+        bool publishShowIds = true)
     {
         var result = new MetadataResult<Series>
         {
@@ -494,10 +499,70 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
 
         result.Item.ProviderIds.Add(ProviderNames.AniDb, animeId);
 
+        if (publishShowIds)
+        {
+            await AddMappedShowIds(result.Item, info, animeId, cancellationToken).ConfigureAwait(false);
+        }
+
         var seriesDataPath = await GetSeriesData(_appPaths, animeId, cancellationToken).ConfigureAwait(false);
         await FetchSeriesInfo(result, seriesDataPath, info.MetadataLanguage ?? "en").ConfigureAwait(false);
 
         return result;
+    }
+
+    /// <summary>
+    /// Writes the TVDB and TMDB ids the mapping sources file a show under onto it, where that is
+    /// turned on. Those sites' image providers, and fanart, are keyed by them, so this is what
+    /// lets them fetch artwork for a show AniDB identified.
+    /// </summary>
+    /// <param name="series">The show being filled in.</param>
+    /// <param name="info">The lookup info, holding whatever ids the item already carries.</param>
+    /// <param name="animeId">The AniDB id of the show.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    private async Task AddMappedShowIds(Series series, SeriesInfo info, string animeId, CancellationToken cancellationToken)
+    {
+        if (!Plugin.Instance.Configuration.PublishMappedIds)
+        {
+            return;
+        }
+
+        var ids = await AniDbMappings.ResolveShowIds(
+            _appPaths,
+            animeId,
+            Logger ?? (ILogger)NullLogger.Instance,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!ids.Any)
+        {
+            return;
+        }
+
+        AddMappedId(series, info.ProviderIds, nameof(MetadataProvider.Tvdb), ids.Tvdb);
+        AddMappedId(series, info.ProviderIds, nameof(MetadataProvider.Tmdb), ids.Tmdb);
+
+        Logger?.LogDebug(
+            "AniDB anime {AnimeId} is filed under TVDB {TvdbId} and TMDB {TmdbId}, which are written onto the show so that whatever is keyed by them can fetch its artwork",
+            animeId,
+            ids.Tvdb,
+            ids.Tmdb);
+    }
+
+    /// <summary>
+    /// Writes one mapped id onto an item, leaving alone an id the item already carries: that one
+    /// was either entered by hand or settled by the provider it belongs to, and either is better
+    /// evidence about the item than a mapping is.
+    /// </summary>
+    /// <param name="item">The item being filled in.</param>
+    /// <param name="known">The ids the item already carries.</param>
+    /// <param name="provider">The provider whose id this is.</param>
+    /// <param name="id">The id, where a source named one.</param>
+    internal static void AddMappedId(IHasProviderIds item, IReadOnlyDictionary<string, string> known, string provider, string? id)
+    {
+        if (!string.IsNullOrEmpty(id) && string.IsNullOrEmpty(known.GetValueOrDefault(provider)))
+        {
+            item.ProviderIds[provider] = id;
+        }
     }
 
     /// <inheritdoc />

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -1114,14 +1114,6 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
 
                             break;
 
-                        case "resources":
-                            using (var subtree = reader.ReadSubtree())
-                            {
-                                await ParseResources(series, subtree).ConfigureAwait(false);
-                            }
-
-                            break;
-
                         case "characters":
                             using (var subtree = reader.ReadSubtree())
                             {
@@ -1137,42 +1129,12 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                             }
 
                             break;
-
-                        case "episodes":
-                            using (var subtree = reader.ReadSubtree())
-                            {
-                                await ParseEpisodes(series, subtree).ConfigureAwait(false);
-                            }
-
-                            break;
                     }
                 }
             }
         }
 
         GenreHelper.CleanupGenres(series);
-    }
-
-    private static async Task ParseEpisodes(Series series, XmlReader reader)
-    {
-        while (await reader.ReadAsync().ConfigureAwait(false))
-        {
-            if (reader.NodeType == XmlNodeType.Element && reader.Name == "episode")
-            {
-                using var episodeSubtree = reader.ReadSubtree();
-                while (await episodeSubtree.ReadAsync().ConfigureAwait(false))
-                {
-                    if (episodeSubtree.NodeType == XmlNodeType.Element)
-                    {
-                        switch (episodeSubtree.Name)
-                        {
-                            case "epno":
-                                break;
-                        }
-                    }
-                }
-            }
-        }
     }
 
     private static bool IsIgnoredTag(int tagId)
@@ -1262,31 +1224,6 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
         }
 
         return blacklist;
-    }
-
-    private static async Task ParseResources(Series series, XmlReader reader)
-    {
-        while (await reader.ReadAsync().ConfigureAwait(false))
-        {
-            if (reader.NodeType == XmlNodeType.Element && reader.Name == "resource")
-            {
-                var type = reader.GetAttribute("type");
-                switch (type)
-                {
-                    case "4":
-                        while (await reader.ReadAsync().ConfigureAwait(false))
-                        {
-                            if (reader.NodeType == XmlNodeType.Element && reader.Name == "url")
-                            {
-                                await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
-                                break;
-                            }
-                        }
-
-                        break;
-                }
-            }
-        }
     }
 
     private static async Task ParseActors(MetadataResult<Series> series, XmlReader reader)

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -1257,6 +1257,11 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
 
     private static void ParseRatings(Series series, XmlReader reader)
     {
+        if (!Plugin.Instance.Configuration.ImportCommunityRating)
+        {
+            return;
+        }
+
         while (reader.Read())
         {
             if (reader.NodeType == XmlNodeType.Element)

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -1015,9 +1015,7 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
 
                         case "description":
                             var description = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
-                            description = description.TrimStart('*').Trim();
-                            series.Overview = ReplaceNewLine(StripAniDbLinks(
-                                Plugin.Instance.Configuration.AniDbReplaceGraves ? description.Replace('`', '\'') : description));
+                            series.Overview = AniDbDescription.Clean(description.TrimStart('*').Trim());
 
                             break;
 
@@ -1202,21 +1200,6 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                 }
             }
         }
-    }
-
-    private static string StripAniDbLinks(string text)
-    {
-        return AniDbUrlRegex().Replace(text, "${name}");
-    }
-
-    /// <summary>
-    /// Replaces new lines with HTML line breaks.
-    /// </summary>
-    /// <param name="text">The text to transform.</param>
-    /// <returns>The transformed text.</returns>
-    public static string ReplaceNewLine(string text)
-    {
-        return text.Replace("\n", "<br>", StringComparison.Ordinal);
     }
 
     private static async Task ParseActors(MetadataResult<Series> series, XmlReader reader)
@@ -1855,9 +1838,6 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
     {
         return Path.Combine(appPaths.CachePath, "anidb", "series", seriesId);
     }
-
-    [GeneratedRegex(@"https?://anidb.net/\w+(/[0-9]+)? \[(?<name>[^\]]*)\]")]
-    private static partial Regex AniDbUrlRegex();
 
     [GeneratedRegex(@"<error[^>]*>.*?</error>", RegexOptions.Singleline)]
     private static partial Regex ErrorRegex();

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -1219,10 +1220,11 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
 
     private static async Task ParseActor(MetadataResult<Series> series, XmlReader reader)
     {
-        string? name = null;
-        string? role = null;
-        string? picture = null;
-        string? personId = null;
+        string? actor = null;
+        string? actorPicture = null;
+        string? actorId = null;
+        string? character = null;
+        string? characterPicture = null;
 
         while (await reader.ReadAsync().ConfigureAwait(false))
         {
@@ -1231,29 +1233,57 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                 switch (reader.Name)
                 {
                     case "name":
-                        role = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
+                        character = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
+                        break;
+
+                    case "picture":
+                        characterPicture = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
                         break;
 
                     case "seiyuu":
                         // Read before the content, which moves off the element these are on.
-                        picture = reader.GetAttribute("picture");
-                        personId = reader.GetAttribute("id");
-                        name = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
+                        actorPicture = reader.GetAttribute("picture");
+                        actorId = reader.GetAttribute("id");
+                        actor = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false);
                         break;
                 }
             }
         }
 
-        if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(role))
+        // Jellyfin holds one person per credit and has no kind of its own for a character, so the
+        // two swap places rather than both being listed: whichever is named takes the credit and
+        // the other becomes the role it is credited with.
+        var showCharacters = Plugin.Instance.Configuration.CastShowsCharacters;
+        var name = showCharacters ? character : actor;
+        var role = showCharacters ? actor : character;
+
+        // A credit needs someone to name. The usual listing names the actor and so needs both,
+        // an actor being worth listing only against the character they play; a character with no
+        // actor recorded is still a character, and is kept where those are what is listed.
+        if (string.IsNullOrEmpty(name) || (!showCharacters && string.IsNullOrEmpty(role)))
         {
-            series.AddPerson(CreatePerson(
-                Plugin.Instance.Configuration.AniDbReplaceGraves ? name.Replace('`', '\'') : name,
-                PersonKind.Actor,
-                role,
-                GetPersonImageUrl(picture),
-                personId));
+            return;
         }
+
+        // A character's AniDB id is not a creator's, and a person's id is written out as a link
+        // to a creator, so a character is listed without an id rather than with one pointing at
+        // whoever happens to hold that creator id.
+        series.AddPerson(CreatePerson(
+            ReplaceGraves(name),
+            PersonKind.Actor,
+            ReplaceGraves(role),
+            GetPersonImageUrl(showCharacters ? characterPicture : actorPicture),
+            showCharacters ? null : actorId));
     }
+
+    /// <summary>
+    /// Replaces the grave accents AniDB romanises a name with, where that is turned on.
+    /// </summary>
+    /// <param name="value">The name, where there is one.</param>
+    /// <returns>The name as it is listed.</returns>
+    [return: NotNullIfNotNull(nameof(value))]
+    private static string? ReplaceGraves(string? value)
+        => Plugin.Instance.Configuration.AniDbReplaceGraves ? value?.Replace('`', '\'') : value;
 
     private static void ParseRatings(Series series, XmlReader reader)
     {
@@ -1332,7 +1362,7 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                     var (kind, role) = GetCreatorRole(type);
 
                     series.AddPerson(CreatePerson(
-                       Plugin.Instance.Configuration.AniDbReplaceGraves ? name.Replace('`', '\'') : name,
+                       ReplaceGraves(name),
                        kind,
                        role,
                        null,

--- a/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/equals_check.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -28,6 +29,36 @@ internal static partial class Equals_check
     private const int FallbackSearchResults = 3;
 
     /// <summary>
+    /// The spellings one romanisation of a name differs from another by, and the pattern each
+    /// becomes. Longest first: the list is walked in order and the first that fits is taken, so
+    /// "and" has to be offered before the "n" inside it.
+    /// </summary>
+    private static readonly (string Spelling, string Pattern)[] _equivalences =
+    [
+        ("gekijyouban", "gekij[y]?ouban"),
+        ("gekijouban", "gekij[y]?ouban"),
+        ("mahoutsukai", "mahou ?tsukai"),
+        ("to aru", "to ?aru"),
+        ("and", "(?:&|and)"),
+        ("ova", "(?:ova|oad)"),
+        ("oad", "(?:ova|oad)"),
+        ("wo", "w?o"),
+        ("re", "re.?"),
+        ("&", "(?:&|and)"),
+        ("c", "[ck]"),
+        ("k", "[ck]"),
+        ("n", "n`?"),
+    ];
+
+    /// <summary>
+    /// The characters a name is allowed to differ from a title by. Punctuation is the first
+    /// thing a romanisation changes, and the two spellings of a name are otherwise the same
+    /// name, so each of these matches any one character or none.
+    /// </summary>
+    private static readonly SearchValues<char> _fuzzyCharacters =
+        SearchValues.Create(@"\*+?|{}[]()^$.#!,–—_=~'`‚‘’„“”:;␣@<>/-");
+
+    /// <summary>
     /// Cut p(%) away from the string.
     /// </summary>
     /// <param name="input">The string to shorten.</param>
@@ -52,53 +83,93 @@ internal static partial class Equals_check
     }
 
     /// <summary>
-    /// Escape string for regex, but fuzzy.
+    /// Builds a pattern that matches a name however it was romanised: loosely about punctuation,
+    /// and treating as equal the spellings that romanisation differs by, such as c and k, OVA and
+    /// OAD, and an ampersand written out as a word.
     /// </summary>
-    /// <param name="a">The string to escape.</param>
-    /// <returns>The fuzzy regex pattern.</returns>
+    /// <remarks>
+    /// Written in one pass over the name rather than as a run of replacements over the pattern
+    /// so far, which is what it used to be. Each replacement there saw what the ones before it
+    /// had written: "OVA" came out as "((OVA)|(((OVA)|(OAD))))" because the OAD rule rewrote the
+    /// OAD the OVA rule had just put there, and the rule pairing "and" with an ampersand never
+    /// fired at all, the rule before it having already turned every n into "n`?".
+    /// </remarks>
+    /// <param name="a">The name to build a pattern from.</param>
+    /// <returns>The fuzzy regex pattern, which is matched without regard to case.</returns>
     public static string FuzzyRegexEscape(string a)
     {
-        a = Regex.Escape(a);
+        var pattern = new StringBuilder(a.Length * 4);
+        var index = 0;
 
-        // Make the escaped characters fuzzy.
-        a = a.Replace(@"\\", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\*", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\+", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\?", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\|", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\{", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\[", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\(", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\)", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\^", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\$", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\.", ".?", StringComparison.Ordinal);
-        a = a.Replace(@"\#", ".?", StringComparison.Ordinal);
+        while (index < a.Length)
+        {
+            var equivalent = MatchEquivalence(a, index);
 
-        // Whitespace.
-        a = a.Replace(@"\ ", ".?.?.?", StringComparison.Ordinal);
-        a = WhitespaceRegex().Replace(a, ".?.?.?");
+            if (equivalent != null)
+            {
+                pattern.Append(equivalent.Value.Pattern);
+                index += equivalent.Value.Spelling.Length;
 
-        // Other characters.
-        a = SpecialCharacterRegex().Replace(a, ".?");
+                continue;
+            }
 
-        // Words.
-        a = SAtEndBoundaryRegex().Replace(a, ".?s");
-        a = a.Replace("Gekijyouban", "Gekijouban", StringComparison.OrdinalIgnoreCase);
-        a = a.Replace("Mahoutsukai", "Mahou ?tsukai", StringComparison.OrdinalIgnoreCase);
-        a = a.Replace("to aru", "to ?aru", StringComparison.OrdinalIgnoreCase);
-        a = a.Replace("re", "re.?", StringComparison.OrdinalIgnoreCase);
-        a = a.Replace("OVA", "((OVA)|(OAD))", StringComparison.OrdinalIgnoreCase);
-        a = a.Replace("OAD", "((OVA)|(OAD))", StringComparison.OrdinalIgnoreCase);
-        a = a.Replace("wo", "w?o", StringComparison.OrdinalIgnoreCase);
-        a = a.Replace("c", "(c|k)", StringComparison.OrdinalIgnoreCase);
-        a = a.Replace("k", "(c|k)", StringComparison.OrdinalIgnoreCase);
-        a = a.Replace("n", "n`?", StringComparison.OrdinalIgnoreCase);
-        a = a.Replace("&", "(&|(and))", StringComparison.OrdinalIgnoreCase);
-        a = a.Replace("and", "(&|(and))", StringComparison.OrdinalIgnoreCase);
+            var character = a[index++];
 
-        return a;
+            if (char.IsWhiteSpace(character))
+            {
+                // A space is where a romanisation is likeliest to disagree, joining two words
+                // one way and hyphenating them another.
+                pattern.Append(".?.?.?");
+            }
+            else if (_fuzzyCharacters.Contains(character))
+            {
+                pattern.Append(".?");
+            }
+            else if ((character is 's' or 'S') && IsWordEnd(a, index))
+            {
+                // A trailing s is often what is left of a syllable another romanisation writes
+                // out, as in "Bleach: Sennen Kessen-hen" against "...Kessenhen s".
+                pattern.Append(".?s");
+            }
+            else
+            {
+                pattern.Append(Regex.Escape(character.ToString()));
+            }
+        }
+
+        return pattern.ToString();
     }
+
+    /// <summary>
+    /// The equivalence the name carries at the given position, longest first.
+    /// </summary>
+    /// <param name="name">The name being read.</param>
+    /// <param name="index">Where in it to look.</param>
+    /// <returns>The equivalence, or <c>null</c> where the name carries none there.</returns>
+    private static (string Spelling, string Pattern)? MatchEquivalence(string name, int index)
+    {
+        foreach (var equivalence in _equivalences)
+        {
+            if (index + equivalence.Spelling.Length <= name.Length
+                && name.AsSpan(index, equivalence.Spelling.Length)
+                    .Equals(equivalence.Spelling, StringComparison.OrdinalIgnoreCase))
+            {
+                return equivalence;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether a word ends at the given position, that being the end of the name or anything
+    /// that is not part of a word.
+    /// </summary>
+    /// <param name="name">The name being read.</param>
+    /// <param name="index">The position just past the character being considered.</param>
+    /// <returns>Whether the word ends there.</returns>
+    private static bool IsWordEnd(string name, int index)
+        => index >= name.Length || (!char.IsLetterOrDigit(name[index]) && name[index] != '_');
 
     /// <summary>
     /// Searches for possible AniDB IDs for name, closest spelling first.
@@ -492,15 +563,6 @@ internal static partial class Equals_check
     {
         return AniDbTitleDownloader.StaticTitlesFilePath;
     }
-
-    [GeneratedRegex(@"\s")]
-    private static partial Regex WhitespaceRegex();
-
-    [GeneratedRegex(@"[!,–—_=~'`‚‘’„“”:;␣#@<>}\]\/\-]")]
-    private static partial Regex SpecialCharacterRegex();
-
-    [GeneratedRegex(@"s\b")]
-    private static partial Regex SAtEndBoundaryRegex();
 
     [GeneratedRegex(@"<title[^>]*>([^<]+)</title>")]
     private static partial Regex TitleRegex();

--- a/README.md
+++ b/README.md
@@ -132,10 +132,18 @@ TMDB, IMDb or TVDB id needs an override only where those two are wrong about it 
 
 2. Build plugin with following command
   ```
-  dotnet publish --configuration Release --output bin
+  dotnet publish Jellyfin.Plugin.AniDB --configuration Release --output bin
   ```
 
 3. Place the dll-file in the `plugins/anidb` folder (you might need to create the folders) of your JF install
+
+## Tests
+
+The matching and parsing that has no server behind it is covered by unit tests.
+
+```
+dotnet test
+```
 
 ## Releasing
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
* Description markup (#87) support
* Add setting for rating opt-out (#34)
* Add setting for characters in the cast (#79)
* Creditless openings, trailers and parodies (#52) support
* Add Fuzzy title matching (#67)
* TVDB and TMDB ids (#51): Add config to write the ids the mapping sources file a show or film under
* Images during an API ban are still valid, so don't block them
* Remove dead code
* Add Tests covering the description helper, episode kinds, movie keys and the fuzzy matcher.