### PR TITLE
Set the production year on a series, and fail rather than blank an item while banned

### DIFF
--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
@@ -58,14 +58,14 @@ public partial class AniDbEpisodeProvider(IServerConfigurationManager configurat
         }
         catch (AniDbBannedException ex)
         {
-            _logger.LogWarning(
-                "Season {SeasonNumber} episode {EpisodeNumber} of AniDB series {SeriesId} could not be looked up because AniDB has banned this client. It stays without metadata until the ban lapses, in {RetryAfter}",
+            _logger.LogDebug(
+                "Season {SeasonNumber} episode {EpisodeNumber} of AniDB series {SeriesId} could not be looked up because AniDB has banned this client, for another {RetryAfter}",
                 info.ParentIndexNumber,
                 info.IndexNumber,
                 seriesId,
                 ex.RetryAfter);
 
-            return result;
+            throw;
         }
 
         if (xml == null || !xml.Exists)

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeasonProvider.cs
@@ -59,13 +59,13 @@ public class AniDbSeasonProvider(IApplicationPaths appPaths, ILibraryManager lib
             }
             catch (AniDbBannedException ex)
             {
-                _logger.LogWarning(
-                    "Season {SeasonNumber} of AniDB series {SeriesId} could not be identified because AniDB has banned this client. It stays without metadata until the ban lapses, in {RetryAfter}, and the next refresh after that will fill it in",
+                _logger.LogDebug(
+                    "Season {SeasonNumber} of AniDB series {SeriesId} could not be identified because AniDB has banned this client, for another {RetryAfter}",
                     info.IndexNumber,
                     seriesId,
                     ex.RetryAfter);
 
-                return result;
+                throw;
             }
         }
 
@@ -114,6 +114,7 @@ public class AniDbSeasonProvider(IApplicationPaths appPaths, ILibraryManager lib
 
             result.Item.Overview = seriesResult.Item.Overview;
             result.Item.PremiereDate = seriesResult.Item.PremiereDate;
+            result.Item.ProductionYear = seriesResult.Item.ProductionYear;
             result.Item.EndDate = seriesResult.Item.EndDate;
             result.Item.CommunityRating = seriesResult.Item.CommunityRating;
             result.Item.Studios = seriesResult.Item.Studios;

--- a/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.AniDB/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -962,6 +962,7 @@ public partial class AniDbSeriesProvider : IRemoteMetadataProvider<Series, Serie
                                 if (DateTime.TryParse(val, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTime date))
                                 {
                                     series.PremiereDate = date;
+                                    series.ProductionYear = date.Year;
                                 }
                             }
 


### PR DESCRIPTION
A series filled from AniDB alone had no year: `<startdate>` was read into the premiere date and nothing set `ProductionYear`.
The episode and season providers answered a ban with an empty result, now this properly propagates.